### PR TITLE
fix: standardize AppImage filename

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -85,6 +85,9 @@
     ],
     "category": "Utility"
   },
+  "appImage": {
+    "artifactName": "${productName}-${version}-x64.${ext}"
+  },
   "nsis": {
     "oneClick": false,
     "allowToChangeInstallationDirectory": true,


### PR DESCRIPTION
## Why this PR

Linux AppImage was missing from releases because the AppImage filename produced by electron-builder
didn’t match the release asset filter (*x64.AppImage vs *x86_64.AppImage). As a result, the release
job never picked it up.

## What this PR does

Standardizes the AppImage artifact filename to the expected \*-x64.AppImage so it matches the
release collection pattern and links.

## How I tested

Ran the GitHub Actions workflow on my fork and confirmed the release includes the AppImage.

- Action run: https://github.com/ascodeasice/PromptHub/actions/runs/21328465707
- Release: https://github.com/ascodeasice/PromptHub/releases/tag/v0.3.9-test2

---

## 为什么要提这个 PR

Linux AppImage 没有出现在 release 中，原因是 electron-builder 生成的 AppImage 文件名与 release 收集
规则不匹配（*x64.AppImage vs *x86_64.AppImage），导致发布时被过滤掉。

## 这个 PR 做了什么

统一 AppImage 的产物文件名为 \*-x64.AppImage，确保与 release 收集规则及下载链接一致。

## 测试方式

在 fork 上运行 GitHub Actions，并确认 release 里包含 AppImage。

- Action 链接：https://github.com/ascodeasice/PromptHub/actions/runs/21328465707
- Release 链接：https://github.com/ascodeasice/PromptHub/releases/tag/v0.3.9-test2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores（构建配置）**
  * 更新应用程序打包配置，优化应用镜像生成设置。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->