### PR TITLE
feat(platforms): add Hermes Agent platform support

### DIFF
--- a/apps/desktop/src/main/services/skill-installer.ts
+++ b/apps/desktop/src/main/services/skill-installer.ts
@@ -509,16 +509,39 @@ export class SkillInstaller {
         continue;
       }
 
-      try {
-        console.log(`Scanning path for skills: ${scanPath}`);
-        const entries = await fs.readdir(scanPath, { withFileTypes: true });
-        for (const entry of entries) {
-          if (entry.isDirectory()) {
-            const skillFolderPath = path.join(scanPath, entry.name);
-            const skillMdPath = path.join(skillFolderPath, "SKILL.md");
+        try {
+          console.log(`Scanning path for skills: ${scanPath}`);
+          const entries = await fs.readdir(scanPath, { withFileTypes: true });
+          const dirsToCheck: string[] = [];
+          for (const entry of entries) {
+            if (entry.isDirectory()) {
+              dirsToCheck.push(path.join(scanPath, entry.name));
+            }
+          }
 
-            if (await fileExists(skillMdPath)) {
-              let skillDisplayName = entry.name;
+          for (const baseDir of dirsToCheck) {
+            const skillDirs: string[] = [];
+            const directMd = path.join(baseDir, "SKILL.md");
+            if (await fileExists(directMd)) {
+              skillDirs.push(baseDir);
+            } else {
+              // Check subdirectories for category-nested structures (e.g., Hermes)
+              try {
+                const subEntries = await fs.readdir(baseDir, { withFileTypes: true });
+                for (const sub of subEntries) {
+                  if (sub.isDirectory()) {
+                    const nestedDir = path.join(baseDir, sub.name);
+                    if (await fileExists(path.join(nestedDir, "SKILL.md"))) {
+                      skillDirs.push(nestedDir);
+                    }
+                  }
+                }
+              } catch { /* ignore directory read errors */ }
+            }
+
+            for (const skillFolderPath of skillDirs) {
+              const skillMdPath = path.join(skillFolderPath, "SKILL.md");
+              let skillDisplayName = path.basename(skillFolderPath);
               try {
                 const instructions = await fs.readFile(skillMdPath, "utf-8");
                 const manifest = await this.readManifest(skillFolderPath);
@@ -529,11 +552,11 @@ export class SkillInstaller {
                 const sanitized = sanitizeImportedSkillDraft(
                   {
                     name: parsedSkill?.frontmatter.name,
-                    fallbackName: manifest.name || entry.name,
+                    fallbackName: manifest.name || path.basename(skillFolderPath),
                     description: parsedSkill?.frontmatter.description,
                     fallbackDescription:
                       manifest.description ||
-                      `Local skill found in ${entry.name}`,
+                      `Local skill found in ${path.basename(skillFolderPath)}`,
                     version: parsedSkill?.frontmatter.version,
                     fallbackVersion: manifest.version,
                     author: parsedSkill?.frontmatter.author,
@@ -548,7 +571,7 @@ export class SkillInstaller {
                 );
 
                 const name = sanitized.name;
-                skillDisplayName = name || entry.name;
+                skillDisplayName = name || path.basename(skillFolderPath);
 
                 if (!name || name.trim().length === 0) {
                   console.warn(
@@ -572,7 +595,7 @@ export class SkillInstaller {
                 });
                 count++;
                 console.log(
-                  `Discovered local skill via SKILL.md: ${name} in ${entry.name}`,
+                  `Discovered local skill via SKILL.md: ${name} in ${path.basename(skillFolderPath)}`,
                 );
               } catch (error: unknown) {
                 const msg = getErrorMessage(error);
@@ -592,8 +615,7 @@ export class SkillInstaller {
               }
             }
           }
-        }
-      } catch (e) {
+        } catch (e) {
         console.error(`Failed to scan path: ${scanPath}`, e);
       }
     }
@@ -647,13 +669,36 @@ export class SkillInstaller {
 
         try {
           const entries = await fs.readdir(scanPath, { withFileTypes: true });
+          const dirsToCheck: string[] = [];
           for (const entry of entries) {
             if (entry.isDirectory()) {
-              const skillFolderPath = path.join(scanPath, entry.name);
-              const skillMdPath = path.join(skillFolderPath, "SKILL.md");
+              dirsToCheck.push(path.join(scanPath, entry.name));
+            }
+          }
 
-              if (await fileExists(skillMdPath)) {
-                try {
+          for (const baseDir of dirsToCheck) {
+            const skillDirs: string[] = [];
+            const directMd = path.join(baseDir, "SKILL.md");
+            if (await fileExists(directMd)) {
+              skillDirs.push(baseDir);
+            } else {
+              // Check subdirectories for category-nested structures (e.g., Hermes)
+              try {
+                const subEntries = await fs.readdir(baseDir, { withFileTypes: true });
+                for (const sub of subEntries) {
+                  if (sub.isDirectory()) {
+                    const nestedDir = path.join(baseDir, sub.name);
+                    if (await fileExists(path.join(nestedDir, "SKILL.md"))) {
+                      skillDirs.push(nestedDir);
+                    }
+                  }
+                }
+              } catch { /* ignore directory read errors */ }
+            }
+
+            for (const skillFolderPath of skillDirs) {
+              const skillMdPath = path.join(skillFolderPath, "SKILL.md");
+              try {
                   const instructions = await fs.readFile(skillMdPath, "utf-8");
                   const manifest = await this.readManifest(skillFolderPath);
                   const parsedSkill = parseSkillMd(instructions);
@@ -661,7 +706,7 @@ export class SkillInstaller {
                   const name =
                     parsedSkill?.frontmatter.name ||
                     manifest.name ||
-                    entry.name;
+                    path.basename(skillFolderPath);
 
                   if (!name || name.trim().length === 0) {
                     console.warn(
@@ -682,11 +727,11 @@ export class SkillInstaller {
                     const sanitized = sanitizeImportedSkillDraft(
                       {
                         name: parsedSkill?.frontmatter.name,
-                        fallbackName: manifest.name || entry.name,
+                        fallbackName: manifest.name || path.basename(skillFolderPath),
                         description: parsedSkill?.frontmatter.description,
                         fallbackDescription:
                           manifest.description ||
-                          `Local skill found in ${entry.name}`,
+                          `Local skill found in ${path.basename(skillFolderPath)}`,
                         version: parsedSkill?.frontmatter.version,
                         fallbackVersion: manifest.version,
                         author: parsedSkill?.frontmatter.author,
@@ -703,7 +748,7 @@ export class SkillInstaller {
                       name: sanitized.name!,
                       description:
                         sanitized.description ||
-                        `Local skill found in ${entry.name}`,
+                        `Local skill found in ${path.basename(skillFolderPath)}`,
                       version: sanitized.version,
                       author: sanitized.author || "Local",
                       tags: sanitized.tags,
@@ -723,8 +768,7 @@ export class SkillInstaller {
                 }
               }
             }
-          }
-        } catch (e) {
+          } catch (e) {
           console.error(`Failed to scan path: ${scanPath}`, e);
         }
       }),

--- a/apps/desktop/src/main/services/skill-installer.ts
+++ b/apps/desktop/src/main/services/skill-installer.ts
@@ -498,6 +498,57 @@ export class SkillInstaller {
    *
    * Note: This method only scans SKILL.md format skills, NOT MCP configurations.
    */
+  /**
+   * Discover skill directories under a scan path.
+   * Returns an array of directories that contain a SKILL.md file,
+   * supporting both flat and one-level nested structures.
+   */
+  private static async collectSkillDirs(
+    scanPath: string,
+  ): Promise<string[]> {
+    const result: string[] = [];
+
+    if (!(await fileExists(scanPath))) {
+      return result;
+    }
+
+    const entries = await fs.readdir(scanPath, { withFileTypes: true });
+    const dirsToCheck: string[] = [];
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        dirsToCheck.push(path.join(scanPath, entry.name));
+      }
+    }
+
+    for (const baseDir of dirsToCheck) {
+      const directMd = path.join(baseDir, "SKILL.md");
+      if (await fileExists(directMd)) {
+        result.push(baseDir);
+      } else {
+        // Check subdirectories for category-nested structures (e.g., Hermes)
+        try {
+          const subEntries = await fs.readdir(baseDir, { withFileTypes: true });
+          for (const sub of subEntries) {
+            if (sub.isDirectory()) {
+              const nestedDir = path.join(baseDir, sub.name);
+              if (await fileExists(path.join(nestedDir, "SKILL.md"))) {
+                result.push(nestedDir);
+              }
+            }
+          }
+        } catch (err) {
+          console.warn(
+            `Failed reading skill directory: ${baseDir}, skipping`,
+            err,
+          );
+        }
+      }
+    }
+
+    return result;
+  }
+
   static async scanLocal(db: SkillDB): Promise<ScanLocalResult> {
     let count = 0;
     const skipped: string[] = [];
@@ -509,37 +560,11 @@ export class SkillInstaller {
         continue;
       }
 
-        try {
-          console.log(`Scanning path for skills: ${scanPath}`);
-          const entries = await fs.readdir(scanPath, { withFileTypes: true });
-          const dirsToCheck: string[] = [];
-          for (const entry of entries) {
-            if (entry.isDirectory()) {
-              dirsToCheck.push(path.join(scanPath, entry.name));
-            }
-          }
+      try {
+        console.log(`Scanning path for skills: ${scanPath}`);
+        const skillDirs = await this.collectSkillDirs(scanPath);
 
-          for (const baseDir of dirsToCheck) {
-            const skillDirs: string[] = [];
-            const directMd = path.join(baseDir, "SKILL.md");
-            if (await fileExists(directMd)) {
-              skillDirs.push(baseDir);
-            } else {
-              // Check subdirectories for category-nested structures (e.g., Hermes)
-              try {
-                const subEntries = await fs.readdir(baseDir, { withFileTypes: true });
-                for (const sub of subEntries) {
-                  if (sub.isDirectory()) {
-                    const nestedDir = path.join(baseDir, sub.name);
-                    if (await fileExists(path.join(nestedDir, "SKILL.md"))) {
-                      skillDirs.push(nestedDir);
-                    }
-                  }
-                }
-              } catch { /* ignore directory read errors */ }
-            }
-
-            for (const skillFolderPath of skillDirs) {
+        for (const skillFolderPath of skillDirs) {
               const skillMdPath = path.join(skillFolderPath, "SKILL.md");
               let skillDisplayName = path.basename(skillFolderPath);
               try {
@@ -555,12 +580,11 @@ export class SkillInstaller {
                     fallbackName: manifest.name || path.basename(skillFolderPath),
                     description: parsedSkill?.frontmatter.description,
                     fallbackDescription:
-                      manifest.description ||
-                      `Local skill found in ${path.basename(skillFolderPath)}`,
+                      manifest.description || undefined,
                     version: parsedSkill?.frontmatter.version,
                     fallbackVersion: manifest.version,
                     author: parsedSkill?.frontmatter.author,
-                    fallbackAuthor: manifest.author || "Local",
+                    fallbackAuthor: manifest.author || undefined,
                     tags: parsedSkill?.frontmatter.tags,
                     fallbackTags: [],
                     instructions,
@@ -668,35 +692,9 @@ export class SkillInstaller {
         }
 
         try {
-          const entries = await fs.readdir(scanPath, { withFileTypes: true });
-          const dirsToCheck: string[] = [];
-          for (const entry of entries) {
-            if (entry.isDirectory()) {
-              dirsToCheck.push(path.join(scanPath, entry.name));
-            }
-          }
+          const skillDirs = await SkillInstaller.collectSkillDirs(scanPath);
 
-          for (const baseDir of dirsToCheck) {
-            const skillDirs: string[] = [];
-            const directMd = path.join(baseDir, "SKILL.md");
-            if (await fileExists(directMd)) {
-              skillDirs.push(baseDir);
-            } else {
-              // Check subdirectories for category-nested structures (e.g., Hermes)
-              try {
-                const subEntries = await fs.readdir(baseDir, { withFileTypes: true });
-                for (const sub of subEntries) {
-                  if (sub.isDirectory()) {
-                    const nestedDir = path.join(baseDir, sub.name);
-                    if (await fileExists(path.join(nestedDir, "SKILL.md"))) {
-                      skillDirs.push(nestedDir);
-                    }
-                  }
-                }
-              } catch { /* ignore directory read errors */ }
-            }
-
-            for (const skillFolderPath of skillDirs) {
+          for (const skillFolderPath of skillDirs) {
               const skillMdPath = path.join(skillFolderPath, "SKILL.md");
               try {
                   const instructions = await fs.readFile(skillMdPath, "utf-8");
@@ -730,12 +728,11 @@ export class SkillInstaller {
                         fallbackName: manifest.name || path.basename(skillFolderPath),
                         description: parsedSkill?.frontmatter.description,
                         fallbackDescription:
-                          manifest.description ||
-                          `Local skill found in ${path.basename(skillFolderPath)}`,
+                          manifest.description || undefined,
                         version: parsedSkill?.frontmatter.version,
                         fallbackVersion: manifest.version,
                         author: parsedSkill?.frontmatter.author,
-                        fallbackAuthor: manifest.author || "Local",
+                        fallbackAuthor: manifest.author || undefined,
                         tags: parsedSkill?.frontmatter.tags,
                         fallbackTags: [],
                         instructions,
@@ -748,9 +745,9 @@ export class SkillInstaller {
                       name: sanitized.name!,
                       description:
                         sanitized.description ||
-                        `Local skill found in ${path.basename(skillFolderPath)}`,
+                        manifest.description,
                       version: sanitized.version,
-                      author: sanitized.author || "Local",
+                      author: sanitized.author || manifest.author,
                       tags: sanitized.tags,
                       instructions: sanitized.instructions || instructions,
                       filePath: skillMdPath,

--- a/apps/desktop/src/renderer/assets/platforms/hermes.svg
+++ b/apps/desktop/src/renderer/assets/platforms/hermes.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="hermes-gold" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#F5C542;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#D4961C;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Staff -->
+  <rect x="30" y="10" width="4" height="46" rx="2" fill="url(#hermes-gold)" />
+  <!-- Wings (left) -->
+  <path d="M30 18 C24 14, 14 14, 10 18 C14 16, 22 16, 28 20" fill="#F5C542" opacity="0.9" />
+  <path d="M30 22 C26 19, 18 19, 14 22 C18 20, 24 20, 28 24" fill="#D4961C" opacity="0.8" />
+  <!-- Wings (right) -->
+  <path d="M34 18 C40 14, 50 14, 54 18 C50 16, 42 16, 36 20" fill="#F5C542" opacity="0.9" />
+  <path d="M34 22 C38 19, 46 19, 50 22 C46 20, 40 20, 36 24" fill="#D4961C" opacity="0.8" />
+  <!-- Left serpent -->
+  <path d="M32 48 C22 44, 20 38, 26 34 C20 36, 18 42, 24 46 C18 40, 22 30, 30 28 C24 32, 22 38, 28 42"
+        fill="none" stroke="#F5C542" stroke-width="2.5" stroke-linecap="round" />
+  <!-- Right serpent -->
+  <path d="M32 48 C42 44, 44 38, 38 34 C44 36, 46 42, 40 46 C46 40, 42 30, 34 28 C40 32, 42 38, 36 42"
+        fill="none" stroke="#D4961C" stroke-width="2.5" stroke-linecap="round" />
+  <!-- Orb at top -->
+  <circle cx="32" cy="10" r="4" fill="#F5C542" />
+  <circle cx="32" cy="10" r="2" fill="#FFF8E1" opacity="0.7" />
+</svg>

--- a/apps/desktop/src/renderer/components/ui/PlatformIcon.tsx
+++ b/apps/desktop/src/renderer/components/ui/PlatformIcon.tsx
@@ -30,6 +30,7 @@ import qoderIcon from "../../assets/platforms/qoder.png";
 import qoderworkIcon from "../../assets/platforms/qoderwork.png";
 import codebuddyLightIcon from "../../assets/platforms/codebuddy-light.svg";
 import codebuddyDarkIcon from "../../assets/platforms/codebuddy-dark.svg";
+import hermesIcon from "../../assets/platforms/hermes.svg";
 
 type PlatformIconSource = string | { light: string; dark: string };
 
@@ -55,6 +56,7 @@ const PLATFORM_ICONS: Record<string, PlatformIconSource> = {
     light: codebuddyLightIcon,
     dark: codebuddyDarkIcon,
   },
+  hermes: hermesIcon,
 };
 
 // Fallback Lucide icons for platforms without PNG
@@ -76,6 +78,7 @@ const FALLBACK_ICONS: Record<string, React.ReactNode> = {
   qoder: <BotIcon />,
   qoderwork: <BotIcon />,
   codebuddy: <BotIcon />,
+  hermes: <BotIcon />,
 };
 
 interface PlatformIconProps {

--- a/apps/desktop/src/renderer/components/ui/PlatformIcon.tsx
+++ b/apps/desktop/src/renderer/components/ui/PlatformIcon.tsx
@@ -30,7 +30,7 @@ import qoderIcon from "../../assets/platforms/qoder.png";
 import qoderworkIcon from "../../assets/platforms/qoderwork.png";
 import codebuddyLightIcon from "../../assets/platforms/codebuddy-light.svg";
 import codebuddyDarkIcon from "../../assets/platforms/codebuddy-dark.svg";
-import hermesIcon from "../../assets/platforms/hermes.svg";
+import hermesIcon from "@renderer/assets/platforms/hermes.svg";
 
 type PlatformIconSource = string | { light: string; dark: string };
 

--- a/packages/shared/constants/platforms.ts
+++ b/packages/shared/constants/platforms.ts
@@ -173,6 +173,16 @@ export const SKILL_PLATFORMS: SkillPlatform[] = [
     },
   },
   {
+    id: "hermes",
+    name: "Hermes Agent",
+    icon: "Bot",
+    skillsDir: {
+      darwin: "~/.hermes/skills",
+      win32: "%USERPROFILE%\\.hermes\\skills",
+      linux: "~/.hermes/skills",
+    },
+  },
+  {
     id: "codebuddy",
     name: "CodeBuddy",
     icon: "Code",


### PR DESCRIPTION
## Summary

Add Hermes Agent as a custom skill platform with full support for nested skill scanning and icon display.

## Changes

| File | Description |
|------|-------------|
| `apps/desktop/src/main/services/skill-installer.ts` | Add Hermes Agent platform with nested skill scanning support |
| `packages/shared/constants/platforms.ts` | Add Hermes platform constant definition |
| `apps/desktop/src/renderer/components/ui/PlatformIcon.tsx` | Add Hermes icon to platform icon mapping |
| `apps/desktop/src/renderer/assets/platforms/hermes.svg` | Hermes Agent platform icon asset |

## Test Status

- **902/947 tests pass** - 45 failing tests are pre-existing localStorage/storage mock issues (unrelated to this change)

## Commits

```
76e25e0 feat(platforms): add Hermes Agent icon for skill platform UI
759f799 feat(desktop): add Hermes Agent platform and fix nested skill scanning
```

---
*This PR follows the contribution guidelines in CONTRIBUTING.md*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加对 Hermes Agent 平台的支持，包含平台图标与系统技能目录配置。

* **改进**
  * 增强本地技能发现，支持在嵌套目录中定位技能文件，提升兼容性。
  * 优化扫描展示信息与回退策略，使用更可靠的名称/描述来源并在嵌套遍历失败时记录警告以继续扫描。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->