### PR TITLE
fix(desktop): stop update dialog flicker loop (#117, #118)

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, lazy, Suspense } from "react";
+import { useCallback, useEffect, useRef, useState, lazy, Suspense } from "react";
 import type { RecoveryCandidate } from "@prompthub/shared/types";
 import { Sidebar, TopBar, MainContent, TitleBar } from "./components/layout";
 import { usePromptStore } from "./stores/prompt.store";
@@ -94,11 +94,20 @@ function App() {
   const [isOsFullscreen, setIsOsFullscreen] = useState(false);
 
   // Update state
-  // 更新状态
   const [showUpdateDialog, setShowUpdateDialog] = useState(false);
   const [initialUpdateStatus, setInitialUpdateStatus] =
     useState<UpdateStatus | null>(null);
   const lastUpdateStatusRef = useRef<UpdateStatus | null>(null);
+
+  // Open the update dialog, seeding the last known status so both the TopBar
+  // button and the custom `open-update-dialog` event start the dialog from
+  // the same baseline. Without this, TopBar opened with a stale
+  // `initialUpdateStatus` from a previous session and the dialog briefly
+  // showed the wrong state before re-checking (review feedback on #122).
+  const openUpdateDialog = useCallback(() => {
+    setInitialUpdateStatus(lastUpdateStatusRef.current);
+    setShowUpdateDialog(true);
+  }, []);
 
   // Close dialog state (Windows)
   // 关闭对话框状态（Windows）
@@ -298,7 +307,6 @@ function App() {
     });
 
     // Listen for update status
-    // 监听更新状态
     const handleStatus = (status: UpdateStatus) => {
       const previousStatus = lastUpdateStatusRef.current;
       const shouldIgnoreTransientChecking =
@@ -324,10 +332,6 @@ function App() {
       // `initialStatus`, so every push would trigger another check, which
       // then produced the next status update, and so on. This was the
       // root cause of the flickering reported in #117/#118.
-      // 弹窗打开期间，弹窗会通过自己的 onStatus 监听维护状态。此处再把状态
-      // 写回 `initialUpdateStatus` 会形成反馈循环：弹窗的 useEffect 依赖
-      // `initialStatus`，每次 prop 变化都会触发新的检查，从而继续推送新的
-      // 状态更新，造成界面闪烁（#117/#118）。
     };
 
     const offUpdaterStatus = window.electron?.updater?.onStatus(handleStatus);
@@ -407,10 +411,8 @@ function App() {
     updateCheckTimer = setInterval(checkForUpdates, UPDATE_CHECK_INTERVAL);
 
     // Listen for manual check trigger - always force a fresh check
-    // 监听手动检查触发（始终强制刷新检查状态）
     const handleOpenUpdate = () => {
-      setInitialUpdateStatus(lastUpdateStatusRef.current);
-      setShowUpdateDialog(true);
+      openUpdateDialog();
     };
     window.addEventListener("open-update-dialog", handleOpenUpdate);
 
@@ -444,7 +446,13 @@ function App() {
       }
       window.removeEventListener("open-update-dialog", handleOpenUpdate);
     };
-  }, [showUpdateDialog]);
+    // `openUpdateDialog` is wrapped in useCallback with an empty dep array,
+    // so it is stable for the lifetime of this component. `handleOpenUpdate`
+    // calls it via closure, so listing `openUpdateDialog` (instead of the
+    // previous `showUpdateDialog`, which was no longer read inside the
+    // effect) avoids the unnecessary listener/timer churn flagged in the
+    // review.
+  }, [openUpdateDialog]);
 
   // Handle dragging a prompt into a folder
   // 处理 Prompt 拖拽到文件夹
@@ -930,7 +938,7 @@ function App() {
               <TopBar
                 onOpenSettings={() => setCurrentPage("settings")}
                 updateAvailable={updateAvailable}
-                onShowUpdateDialog={() => setShowUpdateDialog(true)}
+                onShowUpdateDialog={openUpdateDialog}
               />
 
               <div className="flex min-h-0 flex-1 overflow-hidden">

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -318,9 +318,16 @@ function App() {
         setUpdateAvailable(null);
       }
 
-      if (showUpdateDialog) {
-        setInitialUpdateStatus(status);
-      }
+      // While the dialog is open, it owns its status via its own onStatus
+      // listener. Re-pushing the status into `initialUpdateStatus` here
+      // created a feedback loop — the dialog's useEffect depends on
+      // `initialStatus`, so every push would trigger another check, which
+      // then produced the next status update, and so on. This was the
+      // root cause of the flickering reported in #117/#118.
+      // 弹窗打开期间，弹窗会通过自己的 onStatus 监听维护状态。此处再把状态
+      // 写回 `initialUpdateStatus` 会形成反馈循环：弹窗的 useEffect 依赖
+      // `initialStatus`，每次 prop 变化都会触发新的检查，从而继续推送新的
+      // 状态更新，造成界面闪烁（#117/#118）。
     };
 
     const offUpdaterStatus = window.electron?.updater?.onStatus(handleStatus);

--- a/apps/desktop/src/renderer/components/UpdateDialog.tsx
+++ b/apps/desktop/src/renderer/components/UpdateDialog.tsx
@@ -66,10 +66,14 @@ export function UpdateDialog({ isOpen, onClose, initialStatus }: UpdateDialogPro
   const [isManualRefreshPending, setIsManualRefreshPending] = useState(false);
 
   useEffect(() => {
-    if (initialStatus) {
-      setUpdateStatus(initialStatus);
-      updateStatusRef.current = initialStatus;
-    }
+    // Keep the ref in sync with the `initialStatus` prop, including `null`
+    // transitions. If we only wrote the ref on truthy values (the previous
+    // behavior), a parent that cleared `initialStatus` back to null would
+    // leave the ref holding a stale `available` / `downloaded`, and the
+    // "ignore transient checking" guard plus the `preserveVisibleStatus`
+    // computation would both misbehave on the next open.
+    setUpdateStatus(initialStatus ?? null);
+    updateStatusRef.current = initialStatus ?? null;
   }, [initialStatus]);
 
   useEffect(() => {
@@ -96,8 +100,6 @@ export function UpdateDialog({ isOpen, onClose, initialStatus }: UpdateDialogPro
       // empty dep array, so the closure-captured `updateStatus` would be
       // stale on subsequent invocations and miss already-known
       // 'available'/'downloaded' states.
-      // 通过 ref 读取最新状态：该 effect 依赖为空数组，闭包里 `updateStatus`
-      // 在后续回调中会过期，导致判断"已经处于可用/已下载"的逻辑失效。
       if (
         status.status === 'checking' &&
         isStableUpgradeState(updateStatusRef.current)
@@ -155,16 +157,12 @@ export function UpdateDialog({ isOpen, onClose, initialStatus }: UpdateDialogPro
   }, []);
 
   // When dialog opens, always force a fresh update check (no cache)
-  // 当对话框打开时，总是强制检查更新（不使用缓存）
   //
   // Note: this effect intentionally does NOT depend on `initialStatus`. The
   // parent App pushes status into `initialStatus` while the dialog is open;
   // depending on it here produced a feedback loop where every status update
   // re-triggered the check, which produced the next status, and so on —
   // this was the root cause of the flickering reported in #117/#118.
-  // 注意：此 effect 刻意不依赖 `initialStatus`。父级 App 在弹窗打开期间会把
-  // 状态同步到 `initialStatus`，若在此处依赖会形成反馈循环：每次状态更新
-  // 都会触发新的检查，进而推送下一个状态——这是 #117/#118 闪烁的根因。
   useEffect(() => {
     if (isOpen) {
       setHasAcknowledgedBackup(false);

--- a/apps/desktop/src/renderer/components/UpdateDialog.tsx
+++ b/apps/desktop/src/renderer/components/UpdateDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DownloadIcon, CheckCircleIcon, XIcon, Loader2Icon, RefreshCwIcon, FolderOpenIcon, ExternalLinkIcon, ZapIcon } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
@@ -53,6 +53,7 @@ export function UpdateDialog({ isOpen, onClose, initialStatus }: UpdateDialogPro
   const useUpdateMirror = useSettingsStore((state) => state.useUpdateMirror);
   const updateChannel = useSettingsStore((state) => state.updateChannel);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(initialStatus || null);
+  const updateStatusRef = useRef<UpdateStatus | null>(initialStatus || null);
   const [useMirror, setUseMirror] = useState<boolean>(useUpdateMirror);
   const [currentVersion, setCurrentVersion] = useState<string>('');
   const [platform, setPlatform] = useState<string>('');
@@ -67,8 +68,13 @@ export function UpdateDialog({ isOpen, onClose, initialStatus }: UpdateDialogPro
   useEffect(() => {
     if (initialStatus) {
       setUpdateStatus(initialStatus);
+      updateStatusRef.current = initialStatus;
     }
   }, [initialStatus]);
+
+  useEffect(() => {
+    updateStatusRef.current = updateStatus;
+  }, [updateStatus]);
 
   useEffect(() => {
     // Get current version and platform
@@ -86,13 +92,20 @@ export function UpdateDialog({ isOpen, onClose, initialStatus }: UpdateDialogPro
     // Listen for update status
     // 监听更新状态
     const handleStatus = (status: UpdateStatus) => {
+      // Use the ref to read the latest state — this effect runs once with an
+      // empty dep array, so the closure-captured `updateStatus` would be
+      // stale on subsequent invocations and miss already-known
+      // 'available'/'downloaded' states.
+      // 通过 ref 读取最新状态：该 effect 依赖为空数组，闭包里 `updateStatus`
+      // 在后续回调中会过期，导致判断"已经处于可用/已下载"的逻辑失效。
       if (
         status.status === 'checking' &&
-        isStableUpgradeState(updateStatus)
+        isStableUpgradeState(updateStatusRef.current)
       ) {
         return;
       }
 
+      updateStatusRef.current = status;
       setUpdateStatus(status);
       if (status.status !== 'checking') {
         setIsManualRefreshPending(false);
@@ -143,6 +156,15 @@ export function UpdateDialog({ isOpen, onClose, initialStatus }: UpdateDialogPro
 
   // When dialog opens, always force a fresh update check (no cache)
   // 当对话框打开时，总是强制检查更新（不使用缓存）
+  //
+  // Note: this effect intentionally does NOT depend on `initialStatus`. The
+  // parent App pushes status into `initialStatus` while the dialog is open;
+  // depending on it here produced a feedback loop where every status update
+  // re-triggered the check, which produced the next status, and so on —
+  // this was the root cause of the flickering reported in #117/#118.
+  // 注意：此 effect 刻意不依赖 `initialStatus`。父级 App 在弹窗打开期间会把
+  // 状态同步到 `initialStatus`，若在此处依赖会形成反馈循环：每次状态更新
+  // 都会触发新的检查，进而推送下一个状态——这是 #117/#118 闪烁的根因。
   useEffect(() => {
     if (isOpen) {
       setHasAcknowledgedBackup(false);
@@ -153,10 +175,10 @@ export function UpdateDialog({ isOpen, onClose, initialStatus }: UpdateDialogPro
         setLastManualBackupVersion(status.lastManualBackupVersion);
       });
       void handleCheckUpdate(useUpdateMirror, {
-        preserveVisibleStatus: isStableUpgradeState(initialStatus),
+        preserveVisibleStatus: isStableUpgradeState(updateStatusRef.current),
       });
     }
-  }, [initialStatus, isOpen, updateChannel, useUpdateMirror]);
+  }, [isOpen, updateChannel, useUpdateMirror]);
 
   const handleCheckUpdate = async (
     mirror: boolean,

--- a/apps/desktop/tests/unit/components/update-dialog.test.tsx
+++ b/apps/desktop/tests/unit/components/update-dialog.test.tsx
@@ -250,7 +250,6 @@ describe("UpdateDialog", () => {
     });
 
     // Parent pushing new status values should NOT trigger additional checks.
-    // 父组件推送新的 status 不应再次触发检查。
     await act(async () => {
       rerender(
         <UpdateDialog

--- a/apps/desktop/tests/unit/components/update-dialog.test.tsx
+++ b/apps/desktop/tests/unit/components/update-dialog.test.tsx
@@ -212,4 +212,67 @@ describe("UpdateDialog", () => {
       screen.queryByText("Checking for updates..."),
     ).not.toBeInTheDocument();
   });
+
+  // Regression guard for the flickering loop reported in #117/#118.
+  // The parent (App.tsx) used to push every status change into
+  // `initialStatus` while the dialog was open. The dialog's effect
+  // depended on `initialStatus`, so each push re-ran `updater.check`,
+  // which produced another status, and so on — visually this appeared as
+  // a rapidly flickering dialog where the download button could not be
+  // clicked. After the fix, prop-level `initialStatus` changes must not
+  // retrigger the background check.
+  it("does not re-run updater.check when initialStatus changes while open", async () => {
+    const checkMock = vi.fn().mockResolvedValue({ success: true });
+
+    installWindowMocks({
+      electron: {
+        updater: {
+          check: checkMock,
+          getVersion: vi.fn().mockResolvedValue("0.5.1"),
+          getPlatform: vi.fn().mockResolvedValue("win32"),
+          onStatus: vi.fn(() => vi.fn()),
+        },
+      },
+    });
+
+    const { rerender } = await renderWithI18n(
+      <UpdateDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        initialStatus={{ status: "checking" }}
+      />,
+      { language: "en" },
+    );
+
+    // First open triggers exactly one check.
+    await waitFor(() => {
+      expect(checkMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Parent pushing new status values should NOT trigger additional checks.
+    // 父组件推送新的 status 不应再次触发检查。
+    await act(async () => {
+      rerender(
+        <UpdateDialog
+          isOpen={true}
+          onClose={vi.fn()}
+          initialStatus={availableStatus}
+        />,
+      );
+    });
+    await act(async () => {
+      rerender(
+        <UpdateDialog
+          isOpen={true}
+          onClose={vi.fn()}
+          initialStatus={downloadedStatus}
+        />,
+      );
+    });
+
+    // Give any pending promises a chance to resolve.
+    await waitFor(() => {
+      expect(checkMock).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #117 and #118 — the update dialog flickered rapidly when opened, and the Download button was effectively unclickable because the view kept resetting.

## Root cause

A feedback loop between \`App.tsx\` and \`UpdateDialog\`:

1. \`App.tsx\`'s global \`onStatus\` listener pushed every status update into \`initialUpdateStatus\` while the dialog was open.
2. \`UpdateDialog\`'s \"check on open\" \`useEffect\` depended on \`initialStatus\`, so each push retriggered \`updater.check({...})\`.
3. That produced another status update → re-pushed into \`initialStatus\` → re-triggered the effect, and so on.

While the loop was spinning, the dialog kept re-rendering, the \"checking\" spinner alternated with \"available\", and any click on Download was swallowed by the re-render.

## Fix

- **\`App.tsx\`**: while the dialog is open, let the dialog's own \`onStatus\` listener own the status. Don't re-push into \`initialUpdateStatus\`. The initial value is still seeded once when the dialog opens (via \`handleOpenUpdate\`).
- **\`UpdateDialog\`**: drop \`initialStatus\` from the \"check on open\" deps. Use a new \`updateStatusRef\` to:
  - compute \`preserveVisibleStatus\` against the current local status, and
  - let \`handleStatus\` read the latest value (fixing an unrelated but adjacent stale-closure bug where the check-ignore guard used the first-render value of \`updateStatus\`).

## Tests

- \`apps/desktop/tests/unit/components/update-dialog.test.tsx\` — new regression test confirms that later \`initialStatus\` prop changes no longer retrigger \`updater.check\`. Existing tests continue to pass (4/4).

## Verification

- \`pnpm test -- --run tests/unit/components/update-dialog.test.tsx\` → 4/4 passing.
- \`pnpm lint\` → clean.

## Compatibility notes

- No IPC contract changes.
- No visible behavior changes in the happy path: opening the dialog still triggers a fresh check; mirror/channel changes still trigger a re-check; the dialog still updates its own state from \`updater.onStatus\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了更新对话框打开时的界面闪烁问题
  * 优化更新状态处理，防止在对话框打开期间触发不必要的重复检查

* **Tests**
  * 添加回归测试，确保对话框打开时不会因状态变化而重复触发更新检查

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/legeling/PromptHub/pull/122)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->