### PR TITLE
feat(desktop): drag-to-resize columns, double-click reset, title wrap (#119)

### DIFF
--- a/apps/desktop/src/renderer/components/layout/MainContent.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainContent.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, useRef, Children, isValidElement, cloneElement, memo, lazy, Suspense } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef, Children, isValidElement, cloneElement, memo, lazy, Suspense, type CSSProperties } from 'react';
 import { flushSync } from 'react-dom';
 import { usePromptStore, ViewMode } from '../../stores/prompt.store';
 import { useFolderStore } from '../../stores/folder.store';
@@ -239,7 +239,6 @@ function PromptSkillMainContent() {
   const viewMode = usePromptStore((state) => state.viewMode);
   const incrementUsageCount = usePromptStore((state) => state.incrementUsageCount);
   // Resizable prompt-list pane width (#119)
-  // 可拖拽的 Prompt 列表栏宽度 (#119)
   const promptListPaneWidth = useUIStore((state) => state.promptListPaneWidth);
   const setPromptListPaneWidth = useUIStore(
     (state) => state.setPromptListPaneWidth,
@@ -1636,10 +1635,9 @@ function PromptSkillMainContent() {
         className={getViewClass('card', 'row')}
       >
         {/* Prompt list */}
-        {/* Prompt 列表 */}
         <div
-          className="prompt-list-pane relative border-r border-border flex flex-col bg-card/50"
-          style={{ width: promptListPaneWidth, flexShrink: 0 }}
+          className="prompt-list-pane relative w-[var(--prompt-list-pane-width)] shrink-0 border-r border-border flex flex-col bg-card/50"
+          style={{ '--prompt-list-pane-width': `${promptListPaneWidth}px` } as CSSProperties}
         >
           {/* List header: sort + view switch */}
           {/* 列表头部：排序 + 视图切换 */}

--- a/apps/desktop/src/renderer/components/layout/MainContent.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainContent.tsx
@@ -4,6 +4,11 @@ import { usePromptStore, ViewMode } from '../../stores/prompt.store';
 import { useFolderStore } from '../../stores/folder.store';
 import { useSettingsStore } from '../../stores/settings.store';
 import { useUIStore } from '../../stores/ui.store';
+import {
+  PROMPT_LIST_PANE_WIDTH_DEFAULT,
+  PROMPT_LIST_PANE_WIDTH_MAX,
+  PROMPT_LIST_PANE_WIDTH_MIN,
+} from '../../stores/ui.store';
 import { resolveScenarioModel } from '../../services/ai-defaults';
 import { RulesManager } from '../rules/RulesManager';
 
@@ -20,6 +25,7 @@ import { Input } from '../ui/Input';
 import { Textarea } from '../ui/Textarea';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { CollapsibleThinking } from '../ui/CollapsibleThinking';
+import { ColumnResizer } from '../ui/ColumnResizer';
 import { useToast } from '../ui/Toast';
 import { chatCompletion, generateImage, buildMessagesFromPrompt, multiModelCompare, AITestResult, StreamCallbacks } from '../../services/ai';
 import { useTranslation } from 'react-i18next';
@@ -161,7 +167,10 @@ const PromptCard = memo(function PromptCard({
           {prompt.promptType === 'image' && (
             <ImageIcon className={`w-3 h-3 flex-shrink-0 ${isSelected ? 'text-white/70' : 'text-blue-500'}`} />
           )}
-          <h3 className="font-medium truncate text-sm">
+          <h3
+            className="font-medium text-sm leading-snug break-words line-clamp-2"
+            title={prompt.title}
+          >
             {renderHighlightedText(prompt.title, highlightTerms, highlightClassName)}
           </h3>
         </div>
@@ -171,7 +180,7 @@ const PromptCard = memo(function PromptCard({
         )}
       </div>
       {prompt.description && (
-        <p className={`text-xs truncate mt-0.5 ${isSelected ? 'text-white/70' : 'text-muted-foreground'
+        <p className={`text-xs line-clamp-2 break-words mt-0.5 ${isSelected ? 'text-white/70' : 'text-muted-foreground'
           }`}>
           {renderHighlightedText(prompt.description, highlightTerms, highlightClassName)}
         </p>
@@ -229,6 +238,12 @@ function PromptSkillMainContent() {
   const sortOrder = usePromptStore((state) => state.sortOrder);
   const viewMode = usePromptStore((state) => state.viewMode);
   const incrementUsageCount = usePromptStore((state) => state.incrementUsageCount);
+  // Resizable prompt-list pane width (#119)
+  // 可拖拽的 Prompt 列表栏宽度 (#119)
+  const promptListPaneWidth = useUIStore((state) => state.promptListPaneWidth);
+  const setPromptListPaneWidth = useUIStore(
+    (state) => state.setPromptListPaneWidth,
+  );
   const selectedFolderId = useFolderStore((state) => state.selectedFolderId);
   const unlockedFolderIds = useFolderStore((state) => state.unlockedFolderIds);
   const folders = useFolderStore((state) => state.folders);
@@ -1622,7 +1637,10 @@ function PromptSkillMainContent() {
       >
         {/* Prompt list */}
         {/* Prompt 列表 */}
-        <div className="prompt-list-pane w-80 border-r border-border flex flex-col bg-card/50">
+        <div
+          className="prompt-list-pane relative border-r border-border flex flex-col bg-card/50"
+          style={{ width: promptListPaneWidth, flexShrink: 0 }}
+        >
           {/* List header: sort + view switch */}
           {/* 列表头部：排序 + 视图切换 */}
           <PromptListHeader count={sortedPrompts.length} />
@@ -1652,6 +1670,18 @@ function PromptSkillMainContent() {
                 ))}
               </div>
             )}
+          </div>
+          {/* Drag-to-resize handle for the prompt list pane (#119) */}
+          {/* Prompt 列表栏的拖拽手柄 (#119) */}
+          <div className="absolute inset-y-0 right-0 z-10 flex">
+            <ColumnResizer
+              currentWidth={promptListPaneWidth}
+              min={PROMPT_LIST_PANE_WIDTH_MIN}
+              max={PROMPT_LIST_PANE_WIDTH_MAX}
+              defaultWidth={PROMPT_LIST_PANE_WIDTH_DEFAULT}
+              onResize={setPromptListPaneWidth}
+              ariaLabel={t('prompt.resizeListPaneAria', 'Resize prompt list')}
+            />
           </div>
         </div>
 

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -4,6 +4,12 @@ import { useFolderStore } from '../../stores/folder.store';
 import { usePromptStore } from '../../stores/prompt.store';
 import { useSettingsStore } from '../../stores/settings.store';
 import { useUIStore } from '../../stores/ui.store';
+import {
+  SIDEBAR_PANEL_WIDTH_DEFAULT,
+  SIDEBAR_PANEL_WIDTH_MAX,
+  SIDEBAR_PANEL_WIDTH_MIN,
+} from '../../stores/ui.store';
+import { ColumnResizer } from '../ui/ColumnResizer';
 import { useSkillStore } from '../../stores/skill.store';
 import { FolderModal, PrivateFolderUnlockModal } from '../folder';
 import { useTranslation } from 'react-i18next';
@@ -111,6 +117,10 @@ export function Sidebar({ currentPage, onNavigate, layout = 'combined' }: Sideba
   const appModule = useUIStore((state) => state.appModule);
   const setAppModule = useUIStore((state) => state.setAppModule);
   const isCollapsed = useUIStore((state) => state.isSidebarCollapsed);
+  const sidebarPanelWidth = useUIStore((state) => state.sidebarPanelWidth);
+  const setSidebarPanelWidth = useUIStore(
+    (state) => state.setSidebarPanelWidth,
+  );
   const skillProjects = useSettingsStore((state) => state.skillProjects);
   const addRuleProject = useRulesStore((state) => state.addProjectRule);
   const removeRuleProject = useRulesStore((state) => state.removeProjectRule);
@@ -241,14 +251,20 @@ export function Sidebar({ currentPage, onNavigate, layout = 'combined' }: Sideba
   const showRail = layout !== 'panel';
   const railWidthClass = 'w-20';
   const combinedWidthClass = 'w-[23rem]';
+  // Tailwind can't inline arbitrary dynamic values, so for the resizable
+  // panel layout we supply width via inline style.
+  // 可拖拽的 panel 布局宽度通过内联 style 设置。
+  const panelStyleWidth = layout === 'panel' && !isCollapsed
+    ? { width: sidebarPanelWidth }
+    : undefined;
   const asideClassName =
     layout === 'rail'
       ? `${railWidthClass} border-r border-sidebar-border/60 bg-sidebar-accent/25`
       : layout === 'panel'
-        ? `border-r border-sidebar-border bg-sidebar-background/85 app-wallpaper-panel-strong transition-[width,opacity,transform] duration-300 ease-out ${
+        ? `border-r border-sidebar-border bg-sidebar-background/85 app-wallpaper-panel-strong transition-[opacity,transform] duration-300 ease-out ${
             isCollapsed
               ? 'w-0 -translate-x-4 opacity-0 pointer-events-none border-r-0'
-              : 'w-72 translate-x-0 opacity-100'
+              : 'translate-x-0 opacity-100'
           }`
         : `border-r border-sidebar-border app-left-rail-glass app-wallpaper-panel-strong ${
             isCollapsed ? railWidthClass : combinedWidthClass
@@ -500,6 +516,7 @@ export function Sidebar({ currentPage, onNavigate, layout = 'combined' }: Sideba
     <aside
       ref={sidebarRef}
       className={`relative z-20 flex shrink-0 overflow-hidden transition-all duration-300 ease-in-out ${asideClassName}`}
+      style={panelStyleWidth}
     >
       {showRail && (
       <div className={`flex ${railWidthClass} shrink-0 flex-col bg-sidebar-accent/25 ${layout === 'combined' && !isCollapsed ? 'border-r border-sidebar-border/60' : ''}`}>
@@ -1394,6 +1411,22 @@ export function Sidebar({ currentPage, onNavigate, layout = 'combined' }: Sideba
         />
       )}
        </div>
+      {/* Drag-to-resize handle — only for the panel layout, hidden when */}
+      {/* the panel itself is collapsed. Absolutely positioned so it */}
+      {/* overlays the aside's right border instead of pushing layout. */}
+      {/* 仅在 panel 布局下显示拖拽手柄；折叠时隐藏；绝对定位避免影响布局 (#119) */}
+      {layout === 'panel' && !isCollapsed && (
+        <div className="absolute inset-y-0 right-0 z-10 flex">
+          <ColumnResizer
+            currentWidth={sidebarPanelWidth}
+            min={SIDEBAR_PANEL_WIDTH_MIN}
+            max={SIDEBAR_PANEL_WIDTH_MAX}
+            defaultWidth={SIDEBAR_PANEL_WIDTH_DEFAULT}
+            onResize={setSidebarPanelWidth}
+            ariaLabel={t('sidebar.resizeAria', 'Resize folder sidebar')}
+          />
+        </div>
+      )}
     </aside>
   );
 }

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, memo, type CSSProperties } from 'react';
 import { StarIcon, HashIcon, PlusIcon, LayoutGridIcon, SettingsIcon, XIcon, ChevronDownIcon, ChevronUpIcon, ImageIcon, MessageSquareTextIcon, CommandIcon, CuboidIcon, StoreIcon, GlobeIcon, Clock3Icon, FolderPlusIcon, BookOpenIcon, LinkIcon, FolderOpenIcon, Trash2Icon } from 'lucide-react';
 import { useFolderStore } from '../../stores/folder.store';
 import { usePromptStore } from '../../stores/prompt.store';
@@ -251,11 +251,13 @@ export function Sidebar({ currentPage, onNavigate, layout = 'combined' }: Sideba
   const showRail = layout !== 'panel';
   const railWidthClass = 'w-20';
   const combinedWidthClass = 'w-[23rem]';
-  // Tailwind can't inline arbitrary dynamic values, so for the resizable
-  // panel layout we supply width via inline style.
-  // 可拖拽的 panel 布局宽度通过内联 style 设置。
-  const panelStyleWidth = layout === 'panel' && !isCollapsed
-    ? { width: sidebarPanelWidth }
+  // Dynamic pane widths are delivered via a CSS custom property so the
+  // <aside> can use a Tailwind arbitrary-value utility (see below) rather
+  // than applying an inline width property. Only one CSS variable is set
+  // via `style`, which Tailwind explicitly recommends as the way to wire
+  // up runtime-dynamic sizing to its utility classes.
+  const panelStyle = layout === 'panel' && !isCollapsed
+    ? ({ '--sidebar-panel-width': `${sidebarPanelWidth}px` } as CSSProperties)
     : undefined;
   const asideClassName =
     layout === 'rail'
@@ -264,7 +266,7 @@ export function Sidebar({ currentPage, onNavigate, layout = 'combined' }: Sideba
         ? `border-r border-sidebar-border bg-sidebar-background/85 app-wallpaper-panel-strong transition-[opacity,transform] duration-300 ease-out ${
             isCollapsed
               ? 'w-0 -translate-x-4 opacity-0 pointer-events-none border-r-0'
-              : 'translate-x-0 opacity-100'
+              : 'w-[var(--sidebar-panel-width)] translate-x-0 opacity-100'
           }`
         : `border-r border-sidebar-border app-left-rail-glass app-wallpaper-panel-strong ${
             isCollapsed ? railWidthClass : combinedWidthClass
@@ -516,7 +518,7 @@ export function Sidebar({ currentPage, onNavigate, layout = 'combined' }: Sideba
     <aside
       ref={sidebarRef}
       className={`relative z-20 flex shrink-0 overflow-hidden transition-all duration-300 ease-in-out ${asideClassName}`}
-      style={panelStyleWidth}
+      style={panelStyle}
     >
       {showRail && (
       <div className={`flex ${railWidthClass} shrink-0 flex-col bg-sidebar-accent/25 ${layout === 'combined' && !isCollapsed ? 'border-r border-sidebar-border/60' : ''}`}>

--- a/apps/desktop/src/renderer/components/prompt/PromptGalleryView.tsx
+++ b/apps/desktop/src/renderer/components/prompt/PromptGalleryView.tsx
@@ -139,7 +139,10 @@ const GalleryCard = memo(({
             {/* Content Area */}
             {/* 内容区域 */}
             <div className="flex-1 p-3 flex flex-col gap-2">
-                <h3 className="font-semibold text-sm truncate leading-tight" title={prompt.title}>
+                <h3
+                    className="font-semibold text-sm leading-snug break-words line-clamp-2"
+                    title={prompt.title}
+                >
                     {renderHighlightedText(prompt.title, highlightTerms, highlightClassName)}
                 </h3>
 

--- a/apps/desktop/src/renderer/components/prompt/PromptListView.tsx
+++ b/apps/desktop/src/renderer/components/prompt/PromptListView.tsx
@@ -60,8 +60,12 @@ export function PromptListView({
           {/* 标题和描述 */}
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2">
-              <h3 className={`font-medium text-sm truncate ${selectedId === prompt.id ? 'text-primary' : 'text-foreground'
-                }`}>
+              <h3
+                className={`font-medium text-sm leading-snug break-words line-clamp-2 ${
+                  selectedId === prompt.id ? 'text-primary' : 'text-foreground'
+                }`}
+                title={prompt.title}
+              >
                 {prompt.title}
               </h3>
               {prompt.isFavorite && (
@@ -69,7 +73,7 @@ export function PromptListView({
               )}
             </div>
             {prompt.description && (
-              <p className="text-xs text-muted-foreground truncate mt-0.5">
+              <p className="text-xs text-muted-foreground line-clamp-2 break-words mt-0.5">
                 {prompt.description}
               </p>
             )}

--- a/apps/desktop/src/renderer/components/ui/ColumnResizer.tsx
+++ b/apps/desktop/src/renderer/components/ui/ColumnResizer.tsx
@@ -19,15 +19,12 @@
  * active bar so it blends with the surrounding layout until the user
  * actually reaches for it.
  *
- * ColumnResizer —— 竖向拖拽手柄，用于调整左侧列的宽度（右侧填充剩余空间的
- * 面板布局）。对应 issue #119：大屏用户希望把文件夹/Prompt 列表拉宽。
  */
 import {
   useCallback,
   useEffect,
   useRef,
   useState,
-  type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
@@ -36,7 +33,6 @@ export interface ColumnResizerProps {
   /**
    * Current width of the column being resized, in px. Used as the drag
    * starting point and for keyboard / double-click fallbacks.
-   * 正在拖拽列的当前宽度（px），作为拖拽起点和键盘/双击回退的基准。
    */
   currentWidth: number;
   /** Lower bound in px. Drag will clamp to this. */
@@ -75,7 +71,6 @@ export function ColumnResizer({
 
   // While dragging, temporarily disable text selection on the whole document
   // so the user can move the pointer freely.
-  // 拖拽期间临时禁用全局文本选择，让鼠标可以自由移动。
   useEffect(() => {
     if (!isDragging) return;
     const previousUserSelect = document.body.style.userSelect;
@@ -92,7 +87,6 @@ export function ColumnResizer({
     (event: ReactPointerEvent<HTMLDivElement>) => {
       // Only primary button (left-click / primary touch). Ignore
       // middle-click, right-click, and auxiliary buttons.
-      // 只响应主按键，忽略中键、右键等。
       if (event.button !== 0) return;
       event.preventDefault();
       dragStateRef.current = {
@@ -102,13 +96,18 @@ export function ColumnResizer({
       };
       // setPointerCapture is not always implemented in test environments
       // (jsdom). Guard so missing support doesn't abort the drag.
-      // 某些测试环境（jsdom）没有 setPointerCapture，做一次守卫避免直接抛错。
       try {
         (event.currentTarget as HTMLDivElement).setPointerCapture?.(
           event.pointerId,
         );
-      } catch {
-        // noop — pointer capture is a nice-to-have for sticky drags
+      } catch (error) {
+        // Pointer capture is a nice-to-have for sticky drags; log so the
+        // failure is not completely invisible, then continue — the drag
+        // still works without it.
+        console.warn(
+          "ColumnResizer: setPointerCapture not available",
+          error instanceof Error ? error.message : error,
+        );
       }
       setIsDragging(true);
     },
@@ -134,11 +133,14 @@ export function ColumnResizer({
         (event.currentTarget as HTMLDivElement).releasePointerCapture?.(
           state.pointerId,
         );
-      } catch {
-        // releasePointerCapture can throw if capture was already lost (for
-        // example the pointer was canceled). That's fine — we just want to
-        // reset local state.
-        // releasePointerCapture 在已经失去捕获时会抛错，这里忽略即可。
+      } catch (error) {
+        // releasePointerCapture can throw if capture was already lost
+        // (for example the pointer was canceled). That is expected, but
+        // we log at debug level so support traces are not blind.
+        console.debug(
+          "ColumnResizer: releasePointerCapture no-op",
+          error instanceof Error ? error.message : error,
+        );
       }
       dragStateRef.current = null;
       setIsDragging(false);
@@ -166,21 +168,12 @@ export function ColumnResizer({
         event.key === " "
       ) {
         // Reset on Home / End / Enter / Space for keyboard-only users.
-        // 让仅键盘用户也能通过 Home/End/Enter/空格 复位。
         event.preventDefault();
         onResize(clamp(defaultWidth, min, max));
       }
     },
     [currentWidth, defaultWidth, max, min, onResize],
   );
-
-  const style: CSSProperties = {
-    // Hit-testable wider than the visible bar so the handle is easy to grab.
-    // 可点击区域比可见条宽，便于瞄准。
-    width: 8,
-    flexShrink: 0,
-    touchAction: "none",
-  };
 
   return (
     <div
@@ -197,8 +190,12 @@ export function ColumnResizer({
       onPointerCancel={endDrag}
       onDoubleClick={handleDoubleClick}
       onKeyDown={handleKeyDown}
-      style={style}
-      className={`group relative flex cursor-col-resize items-stretch outline-none focus-visible:bg-primary/20 ${className}`}
+      // Hit area (w-2 = 8px) is wider than the visible bar so the handle
+      // is easy to grab. shrink-0 prevents the flex parent from squeezing
+      // the handle when it runs low on space. touch-none disables the
+      // browser's default touch panning so a swipe on the handle becomes
+      // a pointer event we can drive.
+      className={`group relative flex w-2 shrink-0 cursor-col-resize items-stretch touch-none outline-none focus-visible:bg-primary/20 ${className}`}
       data-testid="column-resizer"
     >
       <div

--- a/apps/desktop/src/renderer/components/ui/ColumnResizer.tsx
+++ b/apps/desktop/src/renderer/components/ui/ColumnResizer.tsx
@@ -1,0 +1,214 @@
+/**
+ * ColumnResizer — a vertical drag handle that lets the user adjust the
+ * width of the column to its left (pane layouts where the next sibling
+ * expands to fill remaining space).
+ *
+ * Designed for issue #119: users on large displays wanted to be able to
+ * expand the folder sidebar and prompt list beyond their fixed defaults.
+ *
+ * Behavior:
+ *   - Pointer down on the handle starts a drag.
+ *   - While dragging, every pointer move calls `onResize(nextWidth)` with
+ *     the clamped new width. Callers can throttle / persist as they like.
+ *   - Double-clicking the handle resets to the provided default width so
+ *     users can recover from an accidental drag without opening settings.
+ *   - The handle also supports keyboard (ArrowLeft / ArrowRight) for
+ *     accessibility; each keystroke moves 16 px, Shift+Arrow moves 64 px.
+ *
+ * The component renders a thin, invisible hit target with a visible hover /
+ * active bar so it blends with the surrounding layout until the user
+ * actually reaches for it.
+ *
+ * ColumnResizer —— 竖向拖拽手柄，用于调整左侧列的宽度（右侧填充剩余空间的
+ * 面板布局）。对应 issue #119：大屏用户希望把文件夹/Prompt 列表拉宽。
+ */
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+
+export interface ColumnResizerProps {
+  /**
+   * Current width of the column being resized, in px. Used as the drag
+   * starting point and for keyboard / double-click fallbacks.
+   * 正在拖拽列的当前宽度（px），作为拖拽起点和键盘/双击回退的基准。
+   */
+  currentWidth: number;
+  /** Lower bound in px. Drag will clamp to this. */
+  min: number;
+  /** Upper bound in px. Drag will clamp to this. */
+  max: number;
+  /** Width to return to on double-click. */
+  defaultWidth: number;
+  /** Called with the new width (already clamped). */
+  onResize: (nextWidth: number) => void;
+  /** Accessible label. */
+  ariaLabel: string;
+  /** Optional className to merge onto the root handle. */
+  className?: string;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function ColumnResizer({
+  currentWidth,
+  min,
+  max,
+  defaultWidth,
+  onResize,
+  ariaLabel,
+  className = "",
+}: ColumnResizerProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStateRef = useRef<{
+    startX: number;
+    startWidth: number;
+    pointerId: number;
+  } | null>(null);
+
+  // While dragging, temporarily disable text selection on the whole document
+  // so the user can move the pointer freely.
+  // 拖拽期间临时禁用全局文本选择，让鼠标可以自由移动。
+  useEffect(() => {
+    if (!isDragging) return;
+    const previousUserSelect = document.body.style.userSelect;
+    const previousCursor = document.body.style.cursor;
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+    return () => {
+      document.body.style.userSelect = previousUserSelect;
+      document.body.style.cursor = previousCursor;
+    };
+  }, [isDragging]);
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      // Only primary button (left-click / primary touch). Ignore
+      // middle-click, right-click, and auxiliary buttons.
+      // 只响应主按键，忽略中键、右键等。
+      if (event.button !== 0) return;
+      event.preventDefault();
+      dragStateRef.current = {
+        startX: event.clientX,
+        startWidth: currentWidth,
+        pointerId: event.pointerId,
+      };
+      // setPointerCapture is not always implemented in test environments
+      // (jsdom). Guard so missing support doesn't abort the drag.
+      // 某些测试环境（jsdom）没有 setPointerCapture，做一次守卫避免直接抛错。
+      try {
+        (event.currentTarget as HTMLDivElement).setPointerCapture?.(
+          event.pointerId,
+        );
+      } catch {
+        // noop — pointer capture is a nice-to-have for sticky drags
+      }
+      setIsDragging(true);
+    },
+    [currentWidth],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const state = dragStateRef.current;
+      if (!state || state.pointerId !== event.pointerId) return;
+      const delta = event.clientX - state.startX;
+      const next = clamp(state.startWidth + delta, min, max);
+      onResize(next);
+    },
+    [max, min, onResize],
+  );
+
+  const endDrag = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const state = dragStateRef.current;
+      if (!state) return;
+      try {
+        (event.currentTarget as HTMLDivElement).releasePointerCapture?.(
+          state.pointerId,
+        );
+      } catch {
+        // releasePointerCapture can throw if capture was already lost (for
+        // example the pointer was canceled). That's fine — we just want to
+        // reset local state.
+        // releasePointerCapture 在已经失去捕获时会抛错，这里忽略即可。
+      }
+      dragStateRef.current = null;
+      setIsDragging(false);
+    },
+    [],
+  );
+
+  const handleDoubleClick = useCallback(() => {
+    onResize(clamp(defaultWidth, min, max));
+  }, [defaultWidth, max, min, onResize]);
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      const step = event.shiftKey ? 64 : 16;
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        onResize(clamp(currentWidth - step, min, max));
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        onResize(clamp(currentWidth + step, min, max));
+      } else if (
+        event.key === "Home" ||
+        event.key === "End" ||
+        event.key === "Enter" ||
+        event.key === " "
+      ) {
+        // Reset on Home / End / Enter / Space for keyboard-only users.
+        // 让仅键盘用户也能通过 Home/End/Enter/空格 复位。
+        event.preventDefault();
+        onResize(clamp(defaultWidth, min, max));
+      }
+    },
+    [currentWidth, defaultWidth, max, min, onResize],
+  );
+
+  const style: CSSProperties = {
+    // Hit-testable wider than the visible bar so the handle is easy to grab.
+    // 可点击区域比可见条宽，便于瞄准。
+    width: 8,
+    flexShrink: 0,
+    touchAction: "none",
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-valuenow={Math.round(currentWidth)}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-label={ariaLabel}
+      tabIndex={0}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onDoubleClick={handleDoubleClick}
+      onKeyDown={handleKeyDown}
+      style={style}
+      className={`group relative flex cursor-col-resize items-stretch outline-none focus-visible:bg-primary/20 ${className}`}
+      data-testid="column-resizer"
+    >
+      <div
+        className={`pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 transition-colors duration-150 ${
+          isDragging
+            ? "bg-primary/80"
+            : "bg-border/40 group-hover:bg-primary/60"
+        }`}
+        aria-hidden
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/i18n/locales/de.json
+++ b/apps/desktop/src/renderer/i18n/locales/de.json
@@ -84,6 +84,7 @@
     "create": "Erstellen",
     "noPrompts": "Keine Prompts",
     "addFirst": "Klicken Sie auf \"Neu\", um Ihren ersten Prompt zu erstellen",
+    "resizeListPaneAria": "Prompt-Liste anpassen",
     "selectPrompt": "Wählen Sie einen Prompt",
     "selectPromptDesc": "Wählen Sie einen Prompt aus der Liste, um Details anzuzeigen, oder klicken Sie auf \"Neu\"",
     "variableHint": "Verwenden Sie {{variablenName}} um Variablen zu definieren",

--- a/apps/desktop/src/renderer/i18n/locales/en.json
+++ b/apps/desktop/src/renderer/i18n/locales/en.json
@@ -86,6 +86,7 @@
     "create": "Create",
     "noPrompts": "No Prompts",
     "addFirst": "Click \"New\" to create your first Prompt",
+    "resizeListPaneAria": "Resize prompt list",
     "selectPrompt": "Select a Prompt",
     "selectPromptDesc": "Select a Prompt from the list to view details, or click \"New\" to create one",
     "variableHint": "Use {{variableName}} to define variables",

--- a/apps/desktop/src/renderer/i18n/locales/es.json
+++ b/apps/desktop/src/renderer/i18n/locales/es.json
@@ -84,6 +84,7 @@
     "create": "Crear",
     "noPrompts": "No hay Prompts",
     "addFirst": "Haz clic en \"Nuevo\" para crear tu primer Prompt",
+    "resizeListPaneAria": "Redimensionar lista de prompts",
     "selectPrompt": "Selecciona un Prompt",
     "selectPromptDesc": "Selecciona un Prompt de la lista para ver detalles, o haz clic en \"Nuevo\"",
     "variableHint": "Usa {{nombreVariable}} para definir variables",

--- a/apps/desktop/src/renderer/i18n/locales/fr.json
+++ b/apps/desktop/src/renderer/i18n/locales/fr.json
@@ -84,6 +84,7 @@
     "create": "Créer",
     "noPrompts": "Aucun Prompt",
     "addFirst": "Cliquez sur \"Nouveau\" pour créer votre premier Prompt",
+    "resizeListPaneAria": "Redimensionner la liste des prompts",
     "selectPrompt": "Sélectionnez un Prompt",
     "selectPromptDesc": "Sélectionnez un Prompt dans la liste pour voir les détails, ou cliquez sur \"Nouveau\"",
     "variableHint": "Utilisez {{nomVariable}} pour définir des variables",

--- a/apps/desktop/src/renderer/i18n/locales/ja.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja.json
@@ -84,6 +84,7 @@
     "create": "作成",
     "noPrompts": "Prompt がありません",
     "addFirst": "「新規作成」をクリックして最初の Prompt を作成",
+    "resizeListPaneAria": "Prompt リストの幅を調整",
     "selectPrompt": "Prompt を選択",
     "selectPromptDesc": "左のリストから Prompt を選択して詳細を表示、または「新規作成」をクリック",
     "variableHint": "{{変数名}} を使用して変数を定義",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -84,6 +84,7 @@
     "create": "建立",
     "noPrompts": "暫無 Prompt",
     "addFirst": "點擊「新建」建立第一個 Prompt",
+    "resizeListPaneAria": "調整 Prompt 列表寬度",
     "selectPrompt": "選擇一個 Prompt",
     "selectPromptDesc": "從左側列表選擇一個 Prompt 查看詳情，或點擊「新建」建立新的 Prompt",
     "variableHint": "使用 {{變數名}} 來定義變數",

--- a/apps/desktop/src/renderer/i18n/locales/zh.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh.json
@@ -86,6 +86,7 @@
     "create": "创建",
     "noPrompts": "暂无 Prompt",
     "addFirst": "点击「新建」创建第一个 Prompt",
+    "resizeListPaneAria": "调整 Prompt 列表宽度",
     "selectPrompt": "选择一个 Prompt",
     "selectPromptDesc": "从左侧列表选择一个 Prompt 查看详情，或点击「新建」创建新的 Prompt",
     "variableHint": "使用 {{变量名}} 来定义变量",

--- a/apps/desktop/src/renderer/stores/ui.store.ts
+++ b/apps/desktop/src/renderer/stores/ui.store.ts
@@ -9,8 +9,6 @@ export type AppModule = ViewMode | "rules";
  * Default and safe bounds for the resizable folder sidebar panel.
  * The max is generous so 4K users can take full advantage of their screen
  * real estate (#119).
- * 可拖拽的文件夹侧栏宽度的默认值与安全边界。
- * 上限较宽，便于 4K 用户充分利用屏幕 (#119)。
  */
 export const SIDEBAR_PANEL_WIDTH_DEFAULT = 288; // matches the original Tailwind `w-72`
 export const SIDEBAR_PANEL_WIDTH_MIN = 220;
@@ -18,7 +16,6 @@ export const SIDEBAR_PANEL_WIDTH_MAX = 640;
 
 /**
  * Default and safe bounds for the resizable prompt-list pane (card view).
- * 可拖拽的 Prompt 列表栏宽度（卡片视图）的默认值与安全边界。
  */
 export const PROMPT_LIST_PANE_WIDTH_DEFAULT = 320; // matches the original Tailwind `w-80`
 export const PROMPT_LIST_PANE_WIDTH_MIN = 240;
@@ -41,7 +38,6 @@ interface UIState {
   toggleSidebar: () => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
   // Resizable column widths (#119)
-  // 可拖拽列宽 (#119)
   sidebarPanelWidth: number;
   promptListPaneWidth: number;
   setSidebarPanelWidth: (width: number) => void;
@@ -94,7 +90,6 @@ export const useUIStore = create<UIState>()(
       // Persist sidebar collapse state AND the user's chosen column widths
       // so the layout survives across sessions (#119). viewMode still resets
       // to 'prompt' on launch by design.
-      // 同时持久化用户拖拽后的列宽，让布局跨会话保留 (#119)。
       partialize: (state) => ({
         isSidebarCollapsed: state.isSidebarCollapsed,
         sidebarPanelWidth: state.sidebarPanelWidth,
@@ -103,7 +98,6 @@ export const useUIStore = create<UIState>()(
       // Safety net: if a persisted width is outside the current bounds (for
       // example after a version bump that narrowed the range), clamp it to
       // a sane value instead of leaving the column in a broken state.
-      // 历史持久化的宽度越界时，收敛到合法范围，避免列宽卡在异常状态。
       merge: (persisted, current) => {
         const merged = { ...current, ...(persisted as Partial<UIState>) };
         return {

--- a/apps/desktop/src/renderer/stores/ui.store.ts
+++ b/apps/desktop/src/renderer/stores/ui.store.ts
@@ -5,6 +5,32 @@ type ViewMode = "prompt" | "skill";
 
 export type AppModule = ViewMode | "rules";
 
+/**
+ * Default and safe bounds for the resizable folder sidebar panel.
+ * The max is generous so 4K users can take full advantage of their screen
+ * real estate (#119).
+ * 可拖拽的文件夹侧栏宽度的默认值与安全边界。
+ * 上限较宽，便于 4K 用户充分利用屏幕 (#119)。
+ */
+export const SIDEBAR_PANEL_WIDTH_DEFAULT = 288; // matches the original Tailwind `w-72`
+export const SIDEBAR_PANEL_WIDTH_MIN = 220;
+export const SIDEBAR_PANEL_WIDTH_MAX = 640;
+
+/**
+ * Default and safe bounds for the resizable prompt-list pane (card view).
+ * 可拖拽的 Prompt 列表栏宽度（卡片视图）的默认值与安全边界。
+ */
+export const PROMPT_LIST_PANE_WIDTH_DEFAULT = 320; // matches the original Tailwind `w-80`
+export const PROMPT_LIST_PANE_WIDTH_MIN = 240;
+export const PROMPT_LIST_PANE_WIDTH_MAX = 720;
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
 interface UIState {
   viewMode: ViewMode;
   appModule: AppModule;
@@ -14,6 +40,13 @@ interface UIState {
   isSidebarCollapsed: boolean;
   toggleSidebar: () => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
+  // Resizable column widths (#119)
+  // 可拖拽列宽 (#119)
+  sidebarPanelWidth: number;
+  promptListPaneWidth: number;
+  setSidebarPanelWidth: (width: number) => void;
+  setPromptListPaneWidth: (width: number) => void;
+  resetColumnWidths: () => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -32,13 +65,61 @@ export const useUIStore = create<UIState>()(
         set((state) => ({ isSidebarCollapsed: !state.isSidebarCollapsed })),
       setSidebarCollapsed: (collapsed) =>
         set({ isSidebarCollapsed: collapsed }),
+      sidebarPanelWidth: SIDEBAR_PANEL_WIDTH_DEFAULT,
+      promptListPaneWidth: PROMPT_LIST_PANE_WIDTH_DEFAULT,
+      setSidebarPanelWidth: (width) =>
+        set({
+          sidebarPanelWidth: clamp(
+            width,
+            SIDEBAR_PANEL_WIDTH_MIN,
+            SIDEBAR_PANEL_WIDTH_MAX,
+          ),
+        }),
+      setPromptListPaneWidth: (width) =>
+        set({
+          promptListPaneWidth: clamp(
+            width,
+            PROMPT_LIST_PANE_WIDTH_MIN,
+            PROMPT_LIST_PANE_WIDTH_MAX,
+          ),
+        }),
+      resetColumnWidths: () =>
+        set({
+          sidebarPanelWidth: SIDEBAR_PANEL_WIDTH_DEFAULT,
+          promptListPaneWidth: PROMPT_LIST_PANE_WIDTH_DEFAULT,
+        }),
     }),
     {
       name: "ui-storage",
-      // Only persist sidebar state; viewMode always resets to 'prompt' on launch
+      // Persist sidebar collapse state AND the user's chosen column widths
+      // so the layout survives across sessions (#119). viewMode still resets
+      // to 'prompt' on launch by design.
+      // 同时持久化用户拖拽后的列宽，让布局跨会话保留 (#119)。
       partialize: (state) => ({
         isSidebarCollapsed: state.isSidebarCollapsed,
+        sidebarPanelWidth: state.sidebarPanelWidth,
+        promptListPaneWidth: state.promptListPaneWidth,
       }),
+      // Safety net: if a persisted width is outside the current bounds (for
+      // example after a version bump that narrowed the range), clamp it to
+      // a sane value instead of leaving the column in a broken state.
+      // 历史持久化的宽度越界时，收敛到合法范围，避免列宽卡在异常状态。
+      merge: (persisted, current) => {
+        const merged = { ...current, ...(persisted as Partial<UIState>) };
+        return {
+          ...merged,
+          sidebarPanelWidth: clamp(
+            merged.sidebarPanelWidth ?? SIDEBAR_PANEL_WIDTH_DEFAULT,
+            SIDEBAR_PANEL_WIDTH_MIN,
+            SIDEBAR_PANEL_WIDTH_MAX,
+          ),
+          promptListPaneWidth: clamp(
+            merged.promptListPaneWidth ?? PROMPT_LIST_PANE_WIDTH_DEFAULT,
+            PROMPT_LIST_PANE_WIDTH_MIN,
+            PROMPT_LIST_PANE_WIDTH_MAX,
+          ),
+        } as UIState;
+      },
     },
   ),
 );

--- a/apps/desktop/tests/unit/components/column-resizer.test.tsx
+++ b/apps/desktop/tests/unit/components/column-resizer.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { ColumnResizer } from "../../../src/renderer/components/ui/ColumnResizer";
+
+/**
+ * Behavioral tests for the drag-to-resize handle introduced in #119.
+ *
+ * We exercise:
+ *   - Pointer drag translates pointer delta into clamped width updates.
+ *   - Double-click restores the default width.
+ *   - Keyboard shortcuts move the column in fine (16 px) and coarse
+ *     (64 px with Shift) steps, and bound to [min, max].
+ *   - Primary button filtering: right-click / middle-click must not start
+ *     a drag.
+ */
+
+function renderResizer(overrides: Partial<Parameters<typeof ColumnResizer>[0]> = {}) {
+  const onResize = vi.fn();
+  const utils = render(
+    <ColumnResizer
+      currentWidth={300}
+      min={200}
+      max={600}
+      defaultWidth={280}
+      onResize={onResize}
+      ariaLabel="Resize"
+      {...overrides}
+    />,
+  );
+  const handle = screen.getByRole("separator", { name: "Resize" });
+  return { handle, onResize, ...utils };
+}
+
+describe("ColumnResizer", () => {
+  it("resizes the column as the pointer moves while dragging", () => {
+    const { handle, onResize } = renderResizer({ currentWidth: 300 });
+
+    fireEvent.pointerDown(handle, { button: 0, clientX: 100, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 160, pointerId: 1 });
+    expect(onResize).toHaveBeenLastCalledWith(360);
+
+    fireEvent.pointerMove(handle, { clientX: 40, pointerId: 1 });
+    expect(onResize).toHaveBeenLastCalledWith(240);
+
+    fireEvent.pointerUp(handle, { pointerId: 1 });
+  });
+
+  it("clamps the width to [min, max] during a drag", () => {
+    const { handle, onResize } = renderResizer({
+      currentWidth: 250,
+      min: 200,
+      max: 400,
+    });
+
+    // Drag past max
+    fireEvent.pointerDown(handle, { button: 0, clientX: 0, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 10_000, pointerId: 1 });
+    expect(onResize).toHaveBeenLastCalledWith(400);
+
+    // Drag past min
+    fireEvent.pointerMove(handle, { clientX: -10_000, pointerId: 1 });
+    expect(onResize).toHaveBeenLastCalledWith(200);
+
+    fireEvent.pointerUp(handle, { pointerId: 1 });
+  });
+
+  it("ignores non-primary buttons so a right-click menu does not start a drag", () => {
+    const { handle, onResize } = renderResizer({ currentWidth: 300 });
+    fireEvent.pointerDown(handle, { button: 2, clientX: 0, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 50, pointerId: 1 });
+    expect(onResize).not.toHaveBeenCalled();
+  });
+
+  it("restores the default width on double-click", () => {
+    const { handle, onResize } = renderResizer({
+      currentWidth: 500,
+      defaultWidth: 280,
+    });
+    fireEvent.doubleClick(handle);
+    expect(onResize).toHaveBeenCalledWith(280);
+  });
+
+  it("supports keyboard resize (ArrowLeft / ArrowRight / Shift)", () => {
+    const { handle, onResize } = renderResizer({ currentWidth: 300 });
+
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    expect(onResize).toHaveBeenLastCalledWith(316);
+
+    fireEvent.keyDown(handle, { key: "ArrowLeft" });
+    expect(onResize).toHaveBeenLastCalledWith(284);
+
+    fireEvent.keyDown(handle, { key: "ArrowRight", shiftKey: true });
+    expect(onResize).toHaveBeenLastCalledWith(364);
+  });
+
+  it("Enter / Space / Home / End all trigger a reset to default", () => {
+    const { handle, onResize } = renderResizer({
+      currentWidth: 500,
+      defaultWidth: 280,
+    });
+
+    for (const key of ["Enter", " ", "Home", "End"]) {
+      onResize.mockClear();
+      fireEvent.keyDown(handle, { key });
+      expect(onResize).toHaveBeenCalledWith(280);
+    }
+  });
+
+  it("exposes the current width through ARIA attributes", () => {
+    const { handle } = renderResizer({ currentWidth: 420 });
+    expect(handle.getAttribute("aria-valuenow")).toBe("420");
+    expect(handle.getAttribute("aria-valuemin")).toBe("200");
+    expect(handle.getAttribute("aria-valuemax")).toBe("600");
+    expect(handle.getAttribute("aria-orientation")).toBe("vertical");
+  });
+});

--- a/apps/desktop/tests/unit/stores/ui-columns.test.ts
+++ b/apps/desktop/tests/unit/stores/ui-columns.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * Regression tests for the resizable column widths added in issue #119.
+ *
+ * These exercises:
+ *   - Default widths match the long-standing Tailwind values (`w-72`, `w-80`)
+ *     so existing users see no visual change until they explicitly resize.
+ *   - `setSidebarPanelWidth` / `setPromptListPaneWidth` clamp to the
+ *     documented bounds so a runaway drag cannot produce a 1-pixel
+ *     unreadable column or a column wider than the window.
+ *   - `resetColumnWidths` returns to defaults so users can escape an
+ *     accidental resize without opening settings.
+ *   - The persist `merge` clamps out-of-range values produced by older
+ *     builds so a stale localStorage row does not leave the layout broken.
+ */
+
+describe("useUIStore resizable columns (issue #119)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("defaults to the legacy Tailwind widths", async () => {
+    const mod = await import("../../../src/renderer/stores/ui.store");
+    const state = mod.useUIStore.getState();
+    expect(state.sidebarPanelWidth).toBe(mod.SIDEBAR_PANEL_WIDTH_DEFAULT);
+    expect(state.promptListPaneWidth).toBe(mod.PROMPT_LIST_PANE_WIDTH_DEFAULT);
+    expect(mod.SIDEBAR_PANEL_WIDTH_DEFAULT).toBe(288);
+    expect(mod.PROMPT_LIST_PANE_WIDTH_DEFAULT).toBe(320);
+  });
+
+  it("clamps sidebar width below the minimum", async () => {
+    const mod = await import("../../../src/renderer/stores/ui.store");
+    mod.useUIStore.getState().setSidebarPanelWidth(10);
+    expect(mod.useUIStore.getState().sidebarPanelWidth).toBe(
+      mod.SIDEBAR_PANEL_WIDTH_MIN,
+    );
+  });
+
+  it("clamps sidebar width above the maximum", async () => {
+    const mod = await import("../../../src/renderer/stores/ui.store");
+    mod.useUIStore.getState().setSidebarPanelWidth(10_000);
+    expect(mod.useUIStore.getState().sidebarPanelWidth).toBe(
+      mod.SIDEBAR_PANEL_WIDTH_MAX,
+    );
+  });
+
+  it("clamps prompt-list-pane width above the maximum", async () => {
+    const mod = await import("../../../src/renderer/stores/ui.store");
+    mod.useUIStore.getState().setPromptListPaneWidth(99_999);
+    expect(mod.useUIStore.getState().promptListPaneWidth).toBe(
+      mod.PROMPT_LIST_PANE_WIDTH_MAX,
+    );
+  });
+
+  it("accepts values inside the allowed range exactly", async () => {
+    const mod = await import("../../../src/renderer/stores/ui.store");
+    mod.useUIStore.getState().setSidebarPanelWidth(420);
+    mod.useUIStore.getState().setPromptListPaneWidth(500);
+    expect(mod.useUIStore.getState().sidebarPanelWidth).toBe(420);
+    expect(mod.useUIStore.getState().promptListPaneWidth).toBe(500);
+  });
+
+  it("rejects NaN / non-finite values (defensive)", async () => {
+    const mod = await import("../../../src/renderer/stores/ui.store");
+    // Non-finite inputs always resolve to the safe minimum, never to the
+    // maximum — an accidental Infinity should not silently max out the
+    // column and hide the rest of the UI.
+    // 非有限值统一回落到最小值，避免 Infinity 意外把列拉到最大遮住其他 UI。
+    mod.useUIStore.getState().setSidebarPanelWidth(Number.NaN);
+    expect(mod.useUIStore.getState().sidebarPanelWidth).toBe(
+      mod.SIDEBAR_PANEL_WIDTH_MIN,
+    );
+    mod.useUIStore.getState().setSidebarPanelWidth(Number.POSITIVE_INFINITY);
+    expect(mod.useUIStore.getState().sidebarPanelWidth).toBe(
+      mod.SIDEBAR_PANEL_WIDTH_MIN,
+    );
+    mod.useUIStore.getState().setSidebarPanelWidth(Number.NEGATIVE_INFINITY);
+    expect(mod.useUIStore.getState().sidebarPanelWidth).toBe(
+      mod.SIDEBAR_PANEL_WIDTH_MIN,
+    );
+  });
+
+  it("resetColumnWidths returns both columns to defaults", async () => {
+    const mod = await import("../../../src/renderer/stores/ui.store");
+    mod.useUIStore.getState().setSidebarPanelWidth(420);
+    mod.useUIStore.getState().setPromptListPaneWidth(500);
+    mod.useUIStore.getState().resetColumnWidths();
+    expect(mod.useUIStore.getState().sidebarPanelWidth).toBe(
+      mod.SIDEBAR_PANEL_WIDTH_DEFAULT,
+    );
+    expect(mod.useUIStore.getState().promptListPaneWidth).toBe(
+      mod.PROMPT_LIST_PANE_WIDTH_DEFAULT,
+    );
+  });
+
+  it("merges an out-of-range persisted width back into the valid range", async () => {
+    // Simulate a previous session that somehow landed outside the allowed
+    // bounds (e.g. after a future min/max change). The store must not
+    // restore the app to a broken layout.
+    // 模拟历史会话里持久化到越界宽度：store 不能把用户带进无法恢复的布局。
+    localStorage.setItem(
+      "ui-storage",
+      JSON.stringify({
+        state: {
+          isSidebarCollapsed: false,
+          sidebarPanelWidth: 99_999,
+          promptListPaneWidth: 5,
+        },
+        version: 0,
+      }),
+    );
+    const mod = await import("../../../src/renderer/stores/ui.store");
+    // zustand persist rehydration runs synchronously for in-memory storage.
+    await Promise.resolve();
+    const state = mod.useUIStore.getState();
+    expect(state.sidebarPanelWidth).toBe(mod.SIDEBAR_PANEL_WIDTH_MAX);
+    expect(state.promptListPaneWidth).toBe(mod.PROMPT_LIST_PANE_WIDTH_MIN);
+  });
+});

--- a/apps/desktop/tests/unit/stores/ui-columns.test.ts
+++ b/apps/desktop/tests/unit/stores/ui-columns.test.ts
@@ -71,7 +71,6 @@ describe("useUIStore resizable columns (issue #119)", () => {
     // Non-finite inputs always resolve to the safe minimum, never to the
     // maximum — an accidental Infinity should not silently max out the
     // column and hide the rest of the UI.
-    // 非有限值统一回落到最小值，避免 Infinity 意外把列拉到最大遮住其他 UI。
     mod.useUIStore.getState().setSidebarPanelWidth(Number.NaN);
     expect(mod.useUIStore.getState().sidebarPanelWidth).toBe(
       mod.SIDEBAR_PANEL_WIDTH_MIN,
@@ -103,7 +102,6 @@ describe("useUIStore resizable columns (issue #119)", () => {
     // Simulate a previous session that somehow landed outside the allowed
     // bounds (e.g. after a future min/max change). The store must not
     // restore the app to a broken layout.
-    // 模拟历史会话里持久化到越界宽度：store 不能把用户带进无法恢复的布局。
     localStorage.setItem(
       "ui-storage",
       JSON.stringify({


### PR DESCRIPTION
## Summary

Three small usability wins asked for in #119, landed together.

1. **Drag-to-resize sidebar columns.** The folder sidebar and the card-view prompt list pane had hard-coded Tailwind widths (\`w-72\` / \`w-80\`), which wasted screen real estate on 4K displays. They are now fully resizable via a vertical drag handle and persist across sessions via the existing Zustand \`localStorage\`. Widths clamp to safe bounds so a runaway drag cannot hide the UI.

2. **Double-click / keyboard reset.** Double-clicking the drag handle restores the column to its default width. Keyboard users can nudge with ArrowLeft / ArrowRight (Shift = 64 px steps) and reset with Enter / Space / Home / End. Fully ARIA-labelled as \`role=\"separator\" aria-orientation=\"vertical\"\` with live \`aria-valuenow\` for assistive tech.

3. **Title auto-wrap in list / card / gallery views.** Prompt titles in PromptCard (card-view list pane), PromptListView, and PromptGalleryView previously used \`truncate\`, so titles longer than the column were silently cut off. They now use \`line-clamp-2 break-words\` — users see a second line before ellipsis, with the full title still available via the \`title=\"\"\` tooltip.

## Architecture

- New reusable \`<ColumnResizer />\` under \`components/ui/\` so future panes can opt in trivially.
- New \`sidebarPanelWidth\` / \`promptListPaneWidth\` fields in \`useUIStore\`, with a \`merge\` function that re-clamps out-of-range persisted values, so schema drift cannot leave the layout stuck in a broken state.

## Tests

- \`tests/unit/stores/ui-columns.test.ts\` — 8 tests: defaults match the legacy Tailwind widths, clamping on both ends, NaN / Infinity reject to min (defensive), reset round-trips, and the persist \`merge\` repair for out-of-range localStorage values.
- \`tests/unit/components/column-resizer.test.tsx\` — 7 tests: pointer drag math, clamp during drag, primary-button filtering (right-click does not start a drag), double-click reset, keyboard step + reset, ARIA attribute exposure.

## Verification

- \`pnpm lint\` → clean
- \`pnpm test -- --run tests/unit/components/column-resizer.test.tsx tests/unit/stores/ui-columns.test.ts\` → 15 / 15 passing

## Notes

- #113 (card-view inline edit for title and user prompt) is already in the repo — see the \`card-detail-inline-edit\` change folder. That part is therefore not duplicated here.
- No IPC, schema, or data migration changes.

Refs #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 侧边栏与提示列表面板支持拖拽调整并记住宽度（含重置功能）
  * 提示标题与描述改为最多两行显示，提升可读性
  * 添加键盘操作与无障碍支持以调整面板宽度
  * 扩展多语言文案以支持面板调整的 ARIA 文本

* **测试**
  * 为面板拖拽、键盘交互与持久化行为新增单元测试

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/legeling/PromptHub/pull/125)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->