### PR TITLE
fix(skill-store): robust search with slug/author and hyphen normalization (#88)

### DIFF
--- a/apps/desktop/src/renderer/components/skill/SkillStore.tsx
+++ b/apps/desktop/src/renderer/components/skill/SkillStore.tsx
@@ -35,6 +35,7 @@ import type {
 import { SKILL_CATEGORIES } from "@prompthub/shared/constants/skill-registry";
 import { getSafetyScanAIConfig } from "./detail-utils";
 import { findInstalledRegistrySkill } from "../../services/skill-store-update";
+import { filterRegistrySkills } from "../../services/skill-store-search";
 import { useSkillStoreRemoteSync } from "./store-remote-sync";
 
 const CATEGORY_ICONS: Record<string, React.ReactNode> = {
@@ -168,30 +169,22 @@ export function SkillStore() {
   }, [isSelectedSourceRemote, loadStoreSource, selectedStoreSourceId]);
 
   const sourceRegistrySkills = useMemo(() => {
-    let baseSkills: RegistrySkill[] = [];
-    if (selectedStoreSourceId === "official") {
-      baseSkills = registrySkills;
-    } else {
-      baseSkills = selectedRemoteEntry?.skills || [];
-    }
+    const baseSkills: RegistrySkill[] =
+      selectedStoreSourceId === "official"
+        ? registrySkills
+        : selectedRemoteEntry?.skills || [];
 
-    if (storeCategory !== "all") {
-      baseSkills = baseSkills.filter(
-        (skill) => skill.category === storeCategory,
-      );
-    }
-
-    if (storeSearchQuery.trim()) {
-      const query = storeSearchQuery.toLowerCase();
-      baseSkills = baseSkills.filter(
-        (skill) =>
-          skill.name.toLowerCase().includes(query) ||
-          skill.description.toLowerCase().includes(query) ||
-          skill.tags.some((tag) => tag.toLowerCase().includes(query)),
-      );
-    }
-
-    return baseSkills;
+    // Centralized filter — see `skill-store-search.ts`. The previous
+    // inline implementation only matched name / description / tags with
+    // a naive `.toLowerCase().includes(...)` and could not find skills
+    // by slug, install_name, or author, nor when the user typed
+    // "hello world" for a slug called "hello-world" (issue #88).
+    // 统一的过滤函数；旧实现只匹配 name/description/tags 且不做归一化，导致
+    // 用户输入 "hello world" 无法命中 "hello-world"，作者/slug 也搜不到 (#88)。
+    return filterRegistrySkills(baseSkills, {
+      category: storeCategory,
+      searchQuery: storeSearchQuery,
+    });
   }, [
     registrySkills,
     selectedRemoteEntry?.skills,

--- a/apps/desktop/src/renderer/components/skill/SkillStore.tsx
+++ b/apps/desktop/src/renderer/components/skill/SkillStore.tsx
@@ -179,8 +179,6 @@ export function SkillStore() {
     // a naive `.toLowerCase().includes(...)` and could not find skills
     // by slug, install_name, or author, nor when the user typed
     // "hello world" for a slug called "hello-world" (issue #88).
-    // 统一的过滤函数；旧实现只匹配 name/description/tags 且不做归一化，导致
-    // 用户输入 "hello world" 无法命中 "hello-world"，作者/slug 也搜不到 (#88)。
     return filterRegistrySkills(baseSkills, {
       category: storeCategory,
       searchQuery: storeSearchQuery,

--- a/apps/desktop/src/renderer/services/skill-store-search.ts
+++ b/apps/desktop/src/renderer/services/skill-store-search.ts
@@ -1,0 +1,135 @@
+/**
+ * Skill store search utilities (issue #88).
+ *
+ * Users reported that skills they could find yesterday were sometimes
+ * "gone" today. Two classes of problems were behind this:
+ *
+ *   1. The original filter only considered `name`, `description`, and
+ *      `tags`, and did so with a naive `includes` on the lowercase text.
+ *      That meant a query like "hello world" would not find a skill
+ *      called "hello-world" or "hello_world", even though those are the
+ *      conventional store naming conventions.
+ *
+ *   2. Some skills surface their distinguishing identifier in other
+ *      fields such as `install_name`, `slug`, or `author`. If the user
+ *      remembered the author / slug, the old search would miss the
+ *      skill completely.
+ *
+ * This module exposes a pure helper so the UI and tests can share the
+ * same algorithm, and so future adjustments (e.g. fuzzy matching) can
+ * be made in a single place.
+ *
+ * 技能商店搜索工具 (#88)。用户反馈有时"昨天能找到的技能今天就找不到了"。
+ * 原因之一是老实现只 includes 匹配 name/description/tags，且没有把
+ * 连字符/下划线归一化，像 "hello world" 这种查询就匹配不到 "hello-world"；
+ * 另外 slug / install_name / author 字段也没纳入搜索。本文件把过滤逻辑抽离
+ * 成纯函数，便于测试与未来迭代（如模糊匹配）。
+ */
+
+import type { RegistrySkill, SkillCategory } from "@prompthub/shared/types";
+
+/**
+ * Normalize a free-form search term so that users typing natural
+ * language ("Hello World") still find slug-style names ("hello-world"
+ * or "hello_world"). We collapse anything that is not a Unicode letter
+ * or digit into a single space, lowercase, and collapse repeated
+ * whitespace.
+ *
+ * The normalized form is intentionally not returned to the user — it
+ * is purely an internal matching key.
+ *
+ * 把自由输入归一化为仅包含 Unicode 字母/数字的小写文本，保留单空格分词。
+ * 归一化后的结果仅用于匹配，不展示给用户。
+ */
+export function normalizeSearchTerm(term: string): string {
+  if (!term) return "";
+  return term
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+/**
+ * Return all searchable fields of a registry skill as a single
+ * pre-normalized haystack. This also protects against fields that may
+ * be `undefined` in ill-formed remote entries (the old implementation
+ * called `.toLowerCase()` directly and crashed).
+ *
+ * 汇总所有可搜索字段并做归一化，同时容忍字段 undefined（旧实现在遇到
+ * undefined description 时直接 throw）。
+ */
+function buildSkillHaystack(skill: RegistrySkill): string {
+  const parts: string[] = [];
+  const pushIfString = (value: unknown) => {
+    if (typeof value === "string" && value.length > 0) {
+      parts.push(value);
+    }
+  };
+
+  pushIfString(skill.name);
+  pushIfString(skill.install_name);
+  pushIfString(skill.slug);
+  pushIfString(skill.description);
+  pushIfString(skill.author);
+  if (Array.isArray(skill.tags)) {
+    for (const tag of skill.tags) {
+      pushIfString(tag);
+    }
+  }
+
+  return normalizeSearchTerm(parts.join(" "));
+}
+
+export interface FilterRegistrySkillsOptions {
+  /** Optional category filter. `"all"` is treated as "no filter". */
+  category?: SkillCategory | "all";
+  /**
+   * Free-form search query. Empty / whitespace-only queries are treated
+   * as "no search" so the full list is returned.
+   */
+  searchQuery?: string;
+}
+
+/**
+ * Filter a list of registry skills by category and search query.
+ *
+ * Behavior:
+ *   - Category `"all"` or absent → no category filter.
+ *   - Empty / whitespace-only query → no search filter.
+ *   - Non-empty query → all whitespace-separated tokens of the
+ *     normalized query must appear as substrings in the normalized
+ *     skill haystack (AND semantics). This lets a user type three
+ *     distinct tokens in any order and still find the skill.
+ *
+ * 根据分类与搜索词过滤技能列表：空分类/空查询不过滤；非空查询按归一化后
+ * 的空格切分，AND 匹配所有 token（子串）。这样即便输入顺序与 slug 不同
+ * 也能命中。
+ */
+export function filterRegistrySkills(
+  skills: readonly RegistrySkill[],
+  options: FilterRegistrySkillsOptions = {},
+): RegistrySkill[] {
+  const { category, searchQuery } = options;
+
+  let result: RegistrySkill[] = [...skills];
+
+  if (category && category !== "all") {
+    result = result.filter((skill) => skill.category === category);
+  }
+
+  const normalizedQuery = normalizeSearchTerm(searchQuery ?? "");
+  if (normalizedQuery.length === 0) {
+    return result;
+  }
+
+  const tokens = normalizedQuery.split(" ").filter(Boolean);
+  if (tokens.length === 0) {
+    return result;
+  }
+
+  return result.filter((skill) => {
+    const haystack = buildSkillHaystack(skill);
+    return tokens.every((token) => haystack.includes(token));
+  });
+}

--- a/apps/desktop/src/renderer/services/skill-store-search.ts
+++ b/apps/desktop/src/renderer/services/skill-store-search.ts
@@ -19,11 +19,6 @@
  * same algorithm, and so future adjustments (e.g. fuzzy matching) can
  * be made in a single place.
  *
- * 技能商店搜索工具 (#88)。用户反馈有时"昨天能找到的技能今天就找不到了"。
- * 原因之一是老实现只 includes 匹配 name/description/tags，且没有把
- * 连字符/下划线归一化，像 "hello world" 这种查询就匹配不到 "hello-world"；
- * 另外 slug / install_name / author 字段也没纳入搜索。本文件把过滤逻辑抽离
- * 成纯函数，便于测试与未来迭代（如模糊匹配）。
  */
 
 import type { RegistrySkill, SkillCategory } from "@prompthub/shared/types";
@@ -38,8 +33,6 @@ import type { RegistrySkill, SkillCategory } from "@prompthub/shared/types";
  * The normalized form is intentionally not returned to the user — it
  * is purely an internal matching key.
  *
- * 把自由输入归一化为仅包含 Unicode 字母/数字的小写文本，保留单空格分词。
- * 归一化后的结果仅用于匹配，不展示给用户。
  */
 export function normalizeSearchTerm(term: string): string {
   if (!term) return "";
@@ -56,8 +49,6 @@ export function normalizeSearchTerm(term: string): string {
  * be `undefined` in ill-formed remote entries (the old implementation
  * called `.toLowerCase()` directly and crashed).
  *
- * 汇总所有可搜索字段并做归一化，同时容忍字段 undefined（旧实现在遇到
- * undefined description 时直接 throw）。
  */
 function buildSkillHaystack(skill: RegistrySkill): string {
   const parts: string[] = [];
@@ -81,6 +72,27 @@ function buildSkillHaystack(skill: RegistrySkill): string {
   return normalizeSearchTerm(parts.join(" "));
 }
 
+/**
+ * Per-skill haystack cache. Remote-market skill objects are effectively
+ * immutable — rebuilding the haystack on every keystroke across hundreds
+ * of skills caused noticeable typing lag in the skill store (review
+ * feedback on #126). Keyed by the RegistrySkill object reference, so a
+ * freshly-fetched registry (different references) automatically bypasses
+ * the cache and the GC can reclaim stale entries when skill references
+ * are dropped.
+ */
+const HAYSTACK_CACHE: WeakMap<RegistrySkill, string> = new WeakMap();
+
+function getSkillHaystack(skill: RegistrySkill): string {
+  const cached = HAYSTACK_CACHE.get(skill);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const computed = buildSkillHaystack(skill);
+  HAYSTACK_CACHE.set(skill, computed);
+  return computed;
+}
+
 export interface FilterRegistrySkillsOptions {
   /** Optional category filter. `"all"` is treated as "no filter". */
   category?: SkillCategory | "all";
@@ -102,9 +114,6 @@ export interface FilterRegistrySkillsOptions {
  *     skill haystack (AND semantics). This lets a user type three
  *     distinct tokens in any order and still find the skill.
  *
- * 根据分类与搜索词过滤技能列表：空分类/空查询不过滤；非空查询按归一化后
- * 的空格切分，AND 匹配所有 token（子串）。这样即便输入顺序与 slug 不同
- * 也能命中。
  */
 export function filterRegistrySkills(
   skills: readonly RegistrySkill[],
@@ -112,24 +121,27 @@ export function filterRegistrySkills(
 ): RegistrySkill[] {
   const { category, searchQuery } = options;
 
-  let result: RegistrySkill[] = [...skills];
-
-  if (category && category !== "all") {
-    result = result.filter((skill) => skill.category === category);
-  }
+  // Category filter first — cheap and avoids building haystacks for
+  // skills that are going to be dropped anyway.
+  const categorized =
+    category && category !== "all"
+      ? skills.filter((skill) => skill.category === category)
+      : skills;
 
   const normalizedQuery = normalizeSearchTerm(searchQuery ?? "");
   if (normalizedQuery.length === 0) {
-    return result;
+    // `filter` always returns a new array in the search path; mirror that
+    // here so callers get stable return-type semantics.
+    return categorized.slice();
   }
 
   const tokens = normalizedQuery.split(" ").filter(Boolean);
   if (tokens.length === 0) {
-    return result;
+    return categorized.slice();
   }
 
-  return result.filter((skill) => {
-    const haystack = buildSkillHaystack(skill);
+  return categorized.filter((skill) => {
+    const haystack = getSkillHaystack(skill);
     return tokens.every((token) => haystack.includes(token));
   });
 }

--- a/apps/desktop/tests/unit/services/skill-store-search.test.ts
+++ b/apps/desktop/tests/unit/services/skill-store-search.test.ts
@@ -145,7 +145,6 @@ describe("filterRegistrySkills (issue #88)", () => {
   it("bridges naming style differences so 'hello world' matches 'hello-world'", () => {
     // Core regression of #88 — the user types the skill name naturally
     // but the slug uses hyphens. The old filter would return nothing.
-    // #88 的核心回归：用户自然输入 "hello world"，但 slug 是 "hello-world"。
     const result = filterRegistrySkills(skills, {
       searchQuery: "hello world",
     });
@@ -212,7 +211,6 @@ describe("filterRegistrySkills (issue #88)", () => {
   it("does not throw when a skill has an undefined description (#88 crash guard)", () => {
     // The old implementation called `.toLowerCase()` directly on description
     // and would crash on ill-formed remote entries with no description.
-    // 旧实现在 description 为 undefined 时直接 throw；这里确认修复后不再崩溃。
     const weird = makeSkill({
       slug: "no-desc",
       name: "No Description",
@@ -253,5 +251,51 @@ describe("filterRegistrySkills (issue #88)", () => {
         (s) => s.slug,
       ),
     ).toEqual(["security-audit"]);
+  });
+
+  // Regression: repeated filter calls across many keystrokes previously
+  // rebuilt the normalized haystack for every skill on every call,
+  // which caused typing lag on large remote registries (review feedback
+  // on #126). The implementation now memoizes the haystack per skill
+  // reference. This test exercises the cache path via a large dataset
+  // and verifies that filtering semantics remain unchanged when the
+  // same skill references are filtered repeatedly with different
+  // queries.
+  it("produces stable results across repeated filter calls on the same skill references", () => {
+    const bulk: RegistrySkill[] = [];
+    for (let i = 0; i < 300; i += 1) {
+      bulk.push(
+        makeSkill({
+          slug: `perf-alpha-${i}`,
+          name: `Perf Alpha ${i}`,
+          description: `cached-haystack fixture ${i}`,
+          tags: ["performance"],
+        }),
+      );
+    }
+
+    // First pass populates the WeakMap cache. Token "alpha" matches
+    // every skill via the slug.
+    const firstAll = filterRegistrySkills(bulk, { searchQuery: "alpha" });
+    expect(firstAll).toHaveLength(bulk.length);
+
+    // Second pass with a different query. If the cache ever returned a
+    // stale or mutated haystack, these results would drift.
+    const cacheFixture = filterRegistrySkills(bulk, {
+      searchQuery: "cached-haystack",
+    });
+    expect(cacheFixture).toHaveLength(bulk.length);
+
+    // Third pass that matches nothing. A broken cache could accidentally
+    // let some skill's old haystack satisfy this.
+    expect(
+      filterRegistrySkills(bulk, { searchQuery: "no-such-thing-xyzzy" }),
+    ).toHaveLength(0);
+
+    // Repeat the first query — results must still match exactly, proving
+    // cache writes don't corrupt the shared state.
+    expect(filterRegistrySkills(bulk, { searchQuery: "alpha" })).toEqual(
+      firstAll,
+    );
   });
 });

--- a/apps/desktop/tests/unit/services/skill-store-search.test.ts
+++ b/apps/desktop/tests/unit/services/skill-store-search.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  filterRegistrySkills,
+  normalizeSearchTerm,
+} from "../../../src/renderer/services/skill-store-search";
+import type { RegistrySkill } from "@prompthub/shared/types";
+
+/**
+ * Regression tests for issue #88 — users reported that skills they could
+ * find yesterday were sometimes "gone" the next day. The underlying filter
+ * had two gaps that this suite guards:
+ *
+ *   1. Naming style mismatch: a skill slug like "hello-world" could not be
+ *      found when the user typed "hello world".
+ *   2. Narrow field coverage: the old filter only looked at name,
+ *      description and tags. Users who remembered the slug, install_name,
+ *      or author missed their skill completely.
+ *
+ * Plus defensive checks: missing fields must not throw.
+ */
+
+function makeSkill(overrides: Partial<RegistrySkill> = {}): RegistrySkill {
+  return {
+    slug: overrides.slug ?? "unknown-skill",
+    name: overrides.name ?? "Unknown Skill",
+    install_name: overrides.install_name ?? overrides.slug ?? "unknown-skill",
+    description: "",
+    category: "general",
+    author: "unknown",
+    source_url: "https://example.com/repo",
+    tags: [],
+    version: "1.0.0",
+    content: "# Skill",
+    ...overrides,
+  };
+}
+
+describe("normalizeSearchTerm", () => {
+  it("lowercases and collapses non-alphanumeric runs to single spaces", () => {
+    expect(normalizeSearchTerm("Hello, World!")).toBe("hello world");
+  });
+
+  it("treats hyphens and underscores as word separators", () => {
+    expect(normalizeSearchTerm("hello-world_v2")).toBe("hello world v2");
+  });
+
+  it("trims leading / trailing separators", () => {
+    expect(normalizeSearchTerm("  --hello--  ")).toBe("hello");
+  });
+
+  it("returns empty string for empty / whitespace-only input", () => {
+    expect(normalizeSearchTerm("")).toBe("");
+    expect(normalizeSearchTerm("   ")).toBe("");
+    expect(normalizeSearchTerm("!!!")).toBe("");
+  });
+
+  it("preserves non-ASCII letters and digits (CJK, accented, emoji digits)", () => {
+    expect(normalizeSearchTerm("中文-测试")).toBe("中文 测试");
+    expect(normalizeSearchTerm("Café ☕ 2024")).toBe("café 2024");
+  });
+});
+
+describe("filterRegistrySkills (issue #88)", () => {
+  const skills: RegistrySkill[] = [
+    makeSkill({ slug: "hello-world", name: "Hello World", tags: ["intro"] }),
+    makeSkill({
+      slug: "pdf-extractor",
+      name: "PDF Extractor",
+      description: "Extract text from PDFs",
+      category: "office",
+      author: "acme",
+      install_name: "pdf_extractor",
+      tags: ["pdf", "office"],
+    }),
+    makeSkill({
+      slug: "security-audit",
+      name: "Security Audit",
+      description: "Scans repositories for vulnerabilities",
+      category: "security",
+      author: "Sec Corp",
+      tags: ["security", "scan"],
+    }),
+    makeSkill({
+      slug: "figma-design",
+      name: "Figma Design Helper",
+      description: "Helps design UI in Figma",
+      category: "design",
+      tags: ["figma", "ui", "design"],
+    }),
+  ];
+
+  it("returns all skills when no filter / query is provided", () => {
+    const result = filterRegistrySkills(skills);
+    expect(result).toHaveLength(4);
+  });
+
+  it("treats category 'all' as no-op", () => {
+    const result = filterRegistrySkills(skills, { category: "all" });
+    expect(result).toHaveLength(4);
+  });
+
+  it("filters by category", () => {
+    const result = filterRegistrySkills(skills, { category: "security" });
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe("security-audit");
+  });
+
+  it("matches the skill name", () => {
+    const result = filterRegistrySkills(skills, { searchQuery: "Figma" });
+    expect(result.map((s) => s.slug)).toEqual(["figma-design"]);
+  });
+
+  it("matches the description", () => {
+    const result = filterRegistrySkills(skills, {
+      searchQuery: "vulnerabilities",
+    });
+    expect(result.map((s) => s.slug)).toEqual(["security-audit"]);
+  });
+
+  it("matches tags", () => {
+    const result = filterRegistrySkills(skills, { searchQuery: "ui" });
+    expect(result.map((s) => s.slug)).toContain("figma-design");
+  });
+
+  it("matches the slug (was broken before #88)", () => {
+    const result = filterRegistrySkills(skills, {
+      searchQuery: "security-audit",
+    });
+    expect(result.map((s) => s.slug)).toEqual(["security-audit"]);
+  });
+
+  it("matches install_name (was broken before #88)", () => {
+    const result = filterRegistrySkills(skills, {
+      searchQuery: "pdf_extractor",
+    });
+    expect(result.map((s) => s.slug)).toEqual(["pdf-extractor"]);
+  });
+
+  it("matches author (was broken before #88)", () => {
+    const result = filterRegistrySkills(skills, { searchQuery: "acme" });
+    expect(result.map((s) => s.slug)).toEqual(["pdf-extractor"]);
+  });
+
+  it("bridges naming style differences so 'hello world' matches 'hello-world'", () => {
+    // Core regression of #88 — the user types the skill name naturally
+    // but the slug uses hyphens. The old filter would return nothing.
+    // #88 的核心回归：用户自然输入 "hello world"，但 slug 是 "hello-world"。
+    const result = filterRegistrySkills(skills, {
+      searchQuery: "hello world",
+    });
+    expect(result.map((s) => s.slug)).toEqual(["hello-world"]);
+  });
+
+  it("treats hyphens and underscores as equivalent tokens", () => {
+    expect(
+      filterRegistrySkills(skills, { searchQuery: "pdf-extractor" }).map(
+        (s) => s.slug,
+      ),
+    ).toEqual(["pdf-extractor"]);
+    expect(
+      filterRegistrySkills(skills, { searchQuery: "pdf extractor" }).map(
+        (s) => s.slug,
+      ),
+    ).toEqual(["pdf-extractor"]);
+    expect(
+      filterRegistrySkills(skills, { searchQuery: "pdf_extractor" }).map(
+        (s) => s.slug,
+      ),
+    ).toEqual(["pdf-extractor"]);
+  });
+
+  it("requires all tokens to match (AND semantics) but not in order", () => {
+    // Both tokens appear in the haystack (name + description + author) of
+    // the PDF skill; they must both match for the skill to be returned.
+    expect(
+      filterRegistrySkills(skills, { searchQuery: "pdf acme" }).map(
+        (s) => s.slug,
+      ),
+    ).toEqual(["pdf-extractor"]);
+    expect(
+      filterRegistrySkills(skills, { searchQuery: "acme pdf" }).map(
+        (s) => s.slug,
+      ),
+    ).toEqual(["pdf-extractor"]);
+  });
+
+  it("returns no matches when at least one AND token is absent", () => {
+    expect(
+      filterRegistrySkills(skills, { searchQuery: "pdf figma" }),
+    ).toHaveLength(0);
+  });
+
+  it("combines category AND search filters", () => {
+    const result = filterRegistrySkills(skills, {
+      category: "design",
+      searchQuery: "figma",
+    });
+    expect(result.map((s) => s.slug)).toEqual(["figma-design"]);
+  });
+
+  it("empty / whitespace-only query is treated as 'no search'", () => {
+    expect(filterRegistrySkills(skills, { searchQuery: "" })).toHaveLength(4);
+    expect(
+      filterRegistrySkills(skills, { searchQuery: "   " }),
+    ).toHaveLength(4);
+    expect(
+      filterRegistrySkills(skills, { searchQuery: "!!!" }),
+    ).toHaveLength(4);
+  });
+
+  it("does not throw when a skill has an undefined description (#88 crash guard)", () => {
+    // The old implementation called `.toLowerCase()` directly on description
+    // and would crash on ill-formed remote entries with no description.
+    // 旧实现在 description 为 undefined 时直接 throw；这里确认修复后不再崩溃。
+    const weird = makeSkill({
+      slug: "no-desc",
+      name: "No Description",
+      description: undefined as unknown as string,
+      tags: undefined as unknown as string[],
+    });
+    expect(() =>
+      filterRegistrySkills([weird], { searchQuery: "description" }),
+    ).not.toThrow();
+    expect(
+      filterRegistrySkills([weird], { searchQuery: "no description" }).map(
+        (s) => s.slug,
+      ),
+    ).toEqual(["no-desc"]);
+  });
+
+  it("handles CJK queries (shipping as remote community skills)", () => {
+    const cjk = makeSkill({
+      slug: "zh-translator",
+      name: "中英互译",
+      description: "Translate between Chinese and English",
+      tags: ["翻译", "中文"],
+    });
+    expect(
+      filterRegistrySkills([cjk], { searchQuery: "中英" }).map((s) => s.slug),
+    ).toEqual(["zh-translator"]);
+    expect(
+      filterRegistrySkills([cjk], { searchQuery: "翻译" }).map((s) => s.slug),
+    ).toEqual(["zh-translator"]);
+  });
+
+  it("is case-insensitive across all fields", () => {
+    expect(
+      filterRegistrySkills(skills, { searchQuery: "HELLO" }).map((s) => s.slug),
+    ).toEqual(["hello-world"]);
+    expect(
+      filterRegistrySkills(skills, { searchQuery: "sec corp" }).map(
+        (s) => s.slug,
+      ),
+    ).toEqual(["security-audit"]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #88. A user reported that skills they could find yesterday were sometimes \"gone\" today. Some of this was a remote fetch problem (addressed separately by #123 — GitHub Token), but the search filter itself had two real gaps that this PR closes.

### Root cause

1. **Naming-style mismatch.** Skills are stored with slug-style names like \`hello-world\` or \`pdf_extractor\`. Users naturally type \"hello world\" or \"pdf extractor\". The old filter used a plain case-insensitive substring match, so \"hello world\" did **not** match \"hello-world\".

2. **Narrow field coverage.** The old filter only looked at \`name\`, \`description\`, and \`tags\`. If a user remembered the \`slug\`, \`install_name\`, or \`author\`, their search missed the skill. It also crashed on remote entries where \`description\` was \`undefined\`, because it called \`description.toLowerCase()\` directly.

### Fix

- New pure helper \`apps/desktop/src/renderer/services/skill-store-search.ts\` exposing \`filterRegistrySkills\` and \`normalizeSearchTerm\`:
  - Normalizes both query and haystack by collapsing non-alphanumeric runs to single spaces, so \`hello world\` / \`hello-world\` / \`hello_world\` all match the same thing.
  - Splits the query into whitespace-separated tokens and requires **all** tokens to match (AND semantics, order-insensitive).
  - Searches \`name\`, \`install_name\`, \`slug\`, \`description\`, \`author\`, and \`tags\` — previously only the first, fourth, and last were used.
  - Is defensive about \`undefined\` fields so ill-formed remote entries no longer crash the render path.
  - Supports CJK / accented / non-ASCII letters via Unicode regex (\`\\p{L}\`, \`\\p{N}\`).
- \`apps/desktop/src/renderer/components/skill/SkillStore.tsx\` now calls the new helper instead of an inline filter.

### Tests

- \`apps/desktop/tests/unit/services/skill-store-search.test.ts\` — **23 tests**, all passing:
  - Normalization edge cases (hyphens, underscores, punctuation, CJK, accented, emoji, whitespace-only).
  - All eight search scenarios: slug, name, install_name, description, author, tags, category, combined.
  - AND-semantics with order-insensitive tokens.
  - Empty / whitespace-only query returns the full list.
  - Crash guard for undefined description / tags.
  - CJK queries.
  - Case-insensitivity across every field.

### Verification

- \`pnpm lint\` → clean
- \`pnpm test -- --run tests/unit/services/skill-store-search.test.ts\` → **23/23** passing

### Notes

- This complements #123 (GitHub Token). Together they address both the \"skill list is empty because the remote fetch failed\" and \"the skill list has skills but my query matched zero of them\" halves of #88.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 改进技能搜索：可在更多字段中搜索（描述、标签等），更可靠地匹配不同命名格式（连字符/下划线）、不区分大小写，并支持 CJK 字符
  * 搜索在重复使用时更稳定且响应更快

* **测试**
  * 新增覆盖多场景的搜索单元测试套件

* **重构**
  * 优化并统一了技能存储的搜索逻辑

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/legeling/PromptHub/pull/126)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->