### PR TITLE
fix(ssr): add svg-captcha to Vite SSR external config

### DIFF
--- a/apps/web/vite.server.config.ts
+++ b/apps/web/vite.server.config.ts
@@ -21,11 +21,11 @@ export default defineConfig({
       output: {
         entryFileNames: 'index.js',
       },
-      external: [/^node:/, 'node-sqlite3-wasm', 'bcryptjs'],
+      external: [/^node:/, 'node-sqlite3-wasm', 'bcryptjs', 'svg-captcha'],
     },
   },
   ssr: {
     noExternal: true,
-    external: ['node-sqlite3-wasm', 'bcryptjs'],
+    external: ['node-sqlite3-wasm', 'bcryptjs', 'svg-captcha'],
   },
 });


### PR DESCRIPTION
## Summary
- Add `svg-captcha` to Vite SSR `rollupOptions.external` and `ssr.external` config
- Prevents Rollup from incorrectly bundling the Node.js native dependency `svg-captcha` into the server bundle, which would cause build/runtime errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 更新了 Vite 服务端渲染构建配置中的外部依赖处理，优化了构建输出和依赖解析流程。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/legeling/PromptHub/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->