### PR TITLE
fix: add globalRuleFile for Kilo Code platform for rules scanning

### DIFF
--- a/packages/shared/constants/platforms.ts
+++ b/packages/shared/constants/platforms.ts
@@ -271,6 +271,7 @@ export const SKILL_PLATFORMS: SkillPlatform[] = [
       linux: "~/.kilo",
     },
     skillsRelativePath: "skills",
+    globalRuleFile: "rules/global.md",
   },
   {
     id: "amp",

--- a/packages/shared/constants/rules.ts
+++ b/packages/shared/constants/rules.ts
@@ -16,6 +16,7 @@ const windsurfPlatform = requirePlatform("windsurf");
 const openclawPlatform = requirePlatform("openclaw");
 const hermesPlatform = requirePlatform("hermes");
 const ampPlatform = requirePlatform("amp");
+const kiloPlatform = requirePlatform("kilo");
 
 export const RULE_FILE_GROUPS = ["workspace", "assistant", "tooling"] as const;
 
@@ -28,6 +29,7 @@ export const RULE_PLATFORM_ORDER = [
   "openclaw",
   "hermes",
   "amp",
+  "kilo",
 ] as const;
 
 export const KNOWN_RULE_FILE_TEMPLATES = {
@@ -121,6 +123,18 @@ export const KNOWN_RULE_FILE_TEMPLATES = {
     name: "AGENTS.md",
     description:
       "Global Amp rules loaded from the local Amp configuration. Amp also checks $HOME/.config/AGENTS.md as a fallback.",
+    group: "tooling",
+  },
+  "kilo-global": {
+    id: "kilo-global",
+    platformId: "kilo",
+    platformName: kiloPlatform.name,
+    platformIcon: kiloPlatform.icon,
+    platformDescription:
+      "Global Kilo Code rules stored in the local Kilo Code rules directory.",
+    name: "global.md",
+    description:
+      "Global Kilo Code rules loaded from the local Kilo Code configuration. Kilo Code reads all .md files in ~/.kilo/rules/.",
     group: "tooling",
   },
 } as const;


### PR DESCRIPTION
## 问题

Kilo Code 平台在 PromptHub 的 Rules 工作区中无法扫描到全局规则，`data/rules/global/kilo/` 目录也不会被创建。

## 根因

Kilo Code 在 `platforms.ts` 中只有 `skillsRelativePath: "skills"`（用于 Skill 安装），**缺少 `globalRuleFile` 属性**。因此：

- `getPlatformGlobalRulePath()` 返回 `null` → Rules 工作区跳过 Kilo Code
- `KNOWN_RULE_FILE_TEMPLATES` 中没有 `"kilo-global"` 条目 → 不创建规则目录
- `RULE_PLATFORM_ORDER` 中没有 `"kilo"` → 侧边栏不显示 Kilo Code

## 修复

1. **`platforms.ts`**: 为 Kilo Code 添加 `globalRuleFile: "rules/global.md"`
2. **`rules.ts`**: 添加 `"kilo"` 到 `RULE_PLATFORM_ORDER`，添加 `"kilo-global"` 到 `KNOWN_RULE_FILE_TEMPLATES`

## 为什么选择 `rules/global.md`

Kilo Code 从 `~/.kilo/rules/` 目录读取所有 `.md` 文件作为全局规则（目录模型）。PromptHub 的 Rules 工作区目前只支持单文件模型。选择 `rules/global.md` 作为 `globalRuleFile` 是最合理的折中：

- PromptHub 管理 `~/.kilo/rules/global.md` 这一个文件
- Kilo Code 会读取它，因为它扫描 `~/.kilo/rules/` 下的所有 `.md` 文件
- 文件名 `global.md` 描述性强，不会与其他规则文件冲突

## 测试

- `pnpm typecheck` ✅
- `pnpm lint` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * Kilo Code 平台现已支持全局规则文件配置。
  * 规则系统中新增对 Kilo 平台的支持和相关规则模板。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/legeling/PromptHub/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->