### PR TITLE
feat: add Atlas Cloud AI provider preset

### DIFF
--- a/apps/desktop/src/renderer/components/settings/ai-workbench/EndpointFormModal.tsx
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/EndpointFormModal.tsx
@@ -6,7 +6,11 @@ import { Select } from "../../ui/Select";
 import { getCategoryIcon } from "../../ui/ModelIcons";
 import { PasswordInput } from "../shared";
 import { PROVIDER_OPTIONS } from "./constants";
-import { getProviderInfo } from "./helpers";
+import {
+  getProviderDisplayName,
+  getProviderDisplayLabel,
+  getProviderInfo,
+} from "./helpers";
 import { Modal } from "../../ui/Modal";
 import type { EndpointDraft } from "./types";
 import {
@@ -30,7 +34,7 @@ export function EndpointFormModal({
   const providerInfo = getProviderInfo(endpointDraft.provider);
   const showProtocolField = providerInfo?.allowsCustomProtocol === true;
   const isAddingProvider = endpointDraft.key === "";
-  const providerTypeLabel = providerInfo?.name || endpointDraft.provider;
+  const providerTypeLabel = getProviderDisplayLabel(endpointDraft.provider, t);
   const trimmedApiUrl = endpointDraft.apiUrl.trim();
   const normalizedInput = useMemo(
     () => normalizeApiUrlInput(endpointDraft.apiUrl),
@@ -66,18 +70,21 @@ export function EndpointFormModal({
     baseUrlPreview &&
     baseUrlPreview !== trimmedApiUrl.replace(/\/$/, ""),
   );
-  const providerOptions = PROVIDER_OPTIONS.map((item) => ({
-    value: item.id,
-    label: (
-      <span className="flex min-w-0 items-center gap-2">
-        <span aria-hidden="true" className="shrink-0">
-          {getCategoryIcon(item.iconCategory, 18)}
+  const providerOptions = PROVIDER_OPTIONS.map((item) => {
+    const providerName = getProviderDisplayName(item, t);
+    return {
+      value: item.id,
+      label: (
+        <span className="flex min-w-0 items-center gap-2">
+          <span aria-hidden="true" className="shrink-0">
+            {getCategoryIcon(item.iconCategory, 18)}
+          </span>
+          <span className="truncate">{providerName}</span>
         </span>
-        <span className="truncate">{item.name}</span>
-      </span>
-    ),
-    labelText: item.name,
-  }));
+      ),
+      labelText: providerName,
+    };
+  });
 
   return (
     <Modal
@@ -127,8 +134,10 @@ export function EndpointFormModal({
               setEndpointDraft((prev) =>
                 prev
                   ? (() => {
-                      const previousTypeName =
-                        getProviderInfo(prev.provider)?.name || prev.provider;
+                      const previousTypeName = getProviderDisplayLabel(
+                        prev.provider,
+                        t,
+                      );
                       const shouldReplaceName =
                         isAddingProvider &&
                         (!prev.name.trim() ||
@@ -137,7 +146,9 @@ export function EndpointFormModal({
                       return {
                         ...prev,
                         name: shouldReplaceName
-                          ? provider?.name || value
+                          ? provider
+                            ? getProviderDisplayName(provider, t)
+                            : value
                           : prev.name,
                         provider: value,
                         apiProtocol:

--- a/apps/desktop/src/renderer/components/settings/ai-workbench/EndpointsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/EndpointsSection.tsx
@@ -33,6 +33,7 @@ import {
 import type { AIModelConfig } from "../../../stores/settings.store";
 import { getCategoryIcon } from "../../ui/ModelIcons";
 import {
+  getEndpointDisplayLabel,
   getEndpointDisplayName,
   getEndpointCategory,
   getEndpointHost,
@@ -168,7 +169,8 @@ export function EndpointsSection({
       null,
     [endpointGroups, selectedEndpointKey],
   );
-  const selectedApiKey = selectedGroup?.apiKey || selectedGroup?.models[0]?.apiKey || "";
+  const selectedApiKey =
+    selectedGroup?.apiKey || selectedGroup?.models[0]?.apiKey || "";
   const selectedApiUrl = selectedGroup?.apiUrl || "";
   const [credentialDraft, setCredentialDraft] = useState({
     groupKey: selectedGroup?.key ?? "",
@@ -324,7 +326,10 @@ export function EndpointsSection({
                 <div className="h-px flex-1 bg-border" />
               </div>
               <div className="relative">
-                <SearchIcon aria-hidden="true" className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <SearchIcon
+                  aria-hidden="true"
+                  className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                />
                 <input
                   type="search"
                   value={searchText}
@@ -417,7 +422,10 @@ export function EndpointsSection({
               <div className="h-px flex-1 bg-border" />
             </div>
             <div className="relative mt-3">
-              <SearchIcon aria-hidden="true" className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <SearchIcon
+                aria-hidden="true"
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              />
               <input
                 type="search"
                 value={searchText}
@@ -461,7 +469,7 @@ export function EndpointsSection({
                     </span>
                     <span className="min-w-0 flex-1">
                       <span className="block truncate text-sm font-medium">
-                        {getEndpointDisplayName(group)}
+                        {getEndpointDisplayLabel(group, t)}
                       </span>
                       <span className="block truncate text-[11px] text-muted-foreground">
                         {groupDetail}
@@ -524,7 +532,7 @@ export function EndpointsSection({
                     <div className="min-w-0">
                       <div className="flex flex-wrap items-center gap-2">
                         <h4 className="truncate text-base font-semibold">
-                          {getEndpointDisplayName(selectedGroup)}
+                          {getEndpointDisplayLabel(selectedGroup, t)}
                         </h4>
                         <span className="rounded-md border border-border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
                           {providerMetaLabel}
@@ -533,9 +541,15 @@ export function EndpointsSection({
                           className={`inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-medium ${getStatusToneClass(endpointStatus.tone)}`}
                         >
                           {endpointStatus.tone === "ready" ? (
-                            <CheckCircle2Icon aria-hidden="true" className="h-3 w-3" />
+                            <CheckCircle2Icon
+                              aria-hidden="true"
+                              className="h-3 w-3"
+                            />
                           ) : (
-                            <AlertCircleIcon aria-hidden="true" className="h-3 w-3" />
+                            <AlertCircleIcon
+                              aria-hidden="true"
+                              className="h-3 w-3"
+                            />
                           )}
                           {endpointStatus.label}
                         </span>
@@ -553,9 +567,15 @@ export function EndpointsSection({
                       className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-2.5 text-xs text-muted-foreground hover:bg-muted disabled:opacity-50"
                     >
                       {testingDefault ? (
-                        <Loader2Icon aria-hidden="true" className="h-3.5 w-3.5 animate-spin" />
+                        <Loader2Icon
+                          aria-hidden="true"
+                          className="h-3.5 w-3.5 animate-spin"
+                        />
                       ) : (
-                        <TestTubeIcon aria-hidden="true" className="h-3.5 w-3.5" />
+                        <TestTubeIcon
+                          aria-hidden="true"
+                          className="h-3.5 w-3.5"
+                        />
                       )}
                       {t("settings.aiWorkbenchTestDefault")}
                     </button>
@@ -566,9 +586,15 @@ export function EndpointsSection({
                       className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-2.5 text-xs text-muted-foreground hover:bg-muted disabled:opacity-50"
                     >
                       {testingEndpointKey === selectedGroup.key ? (
-                        <Loader2Icon aria-hidden="true" className="h-3.5 w-3.5 animate-spin" />
+                        <Loader2Icon
+                          aria-hidden="true"
+                          className="h-3.5 w-3.5 animate-spin"
+                        />
                       ) : (
-                        <TestTubeIcon aria-hidden="true" className="h-3.5 w-3.5" />
+                        <TestTubeIcon
+                          aria-hidden="true"
+                          className="h-3.5 w-3.5"
+                        />
                       )}
                       {t("settings.testConnection")}
                     </button>
@@ -587,7 +613,10 @@ export function EndpointsSection({
                   <div className="rounded-lg border border-border/70 bg-muted/20 p-3">
                     <div className="mb-3 flex items-start justify-between gap-3">
                       <div className="text-xs font-medium text-muted-foreground">
-                        {t("settings.aiWorkbenchEndpointCredentials", "Endpoint credentials")}
+                        {t(
+                          "settings.aiWorkbenchEndpointCredentials",
+                          "Endpoint credentials",
+                        )}
                       </div>
                       {credentialsDirty ? (
                         <div className="flex shrink-0 items-center gap-1">
@@ -615,7 +644,10 @@ export function EndpointsSection({
                     </div>
                     <div className="space-y-2">
                       <div className="flex min-w-0 items-center gap-3">
-                        <LinkIcon aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        <LinkIcon
+                          aria-hidden="true"
+                          className="h-4 w-4 shrink-0 text-muted-foreground"
+                        />
                         <label className="min-w-0 flex-1">
                           <span className="mb-1 block text-xs text-muted-foreground">
                             {t("settings.apiUrl")}
@@ -647,7 +679,10 @@ export function EndpointsSection({
                         </label>
                       </div>
                       <div className="flex min-w-0 items-center gap-3">
-                        <KeyRoundIcon aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        <KeyRoundIcon
+                          aria-hidden="true"
+                          className="h-4 w-4 shrink-0 text-muted-foreground"
+                        />
                         <label className="min-w-0 flex-1">
                           <span className="mb-1 block text-xs text-muted-foreground">
                             {t("settings.apiKey")}
@@ -695,9 +730,15 @@ export function EndpointsSection({
                               className="absolute right-1 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                             >
                               {showApiKey ? (
-                                <EyeOffIcon aria-hidden="true" className="h-4 w-4" />
+                                <EyeOffIcon
+                                  aria-hidden="true"
+                                  className="h-4 w-4"
+                                />
                               ) : (
-                                <EyeIcon aria-hidden="true" className="h-4 w-4" />
+                                <EyeIcon
+                                  aria-hidden="true"
+                                  className="h-4 w-4"
+                                />
                               )}
                             </button>
                           </span>
@@ -846,9 +887,15 @@ export function EndpointsSection({
                             className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted disabled:opacity-50"
                           >
                             {testingModelId === model.id ? (
-                              <Loader2Icon aria-hidden="true" className="h-3.5 w-3.5 animate-spin" />
+                              <Loader2Icon
+                                aria-hidden="true"
+                                className="h-3.5 w-3.5 animate-spin"
+                              />
                             ) : (
-                              <TestTubeIcon aria-hidden="true" className="h-3.5 w-3.5" />
+                              <TestTubeIcon
+                                aria-hidden="true"
+                                className="h-3.5 w-3.5"
+                              />
                             )}
                           </button>
                           {!model.isDefault ? (
@@ -859,7 +906,10 @@ export function EndpointsSection({
                               title={t("settings.setDefault")}
                               className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted"
                             >
-                              <StarIcon aria-hidden="true" className="h-3.5 w-3.5" />
+                              <StarIcon
+                                aria-hidden="true"
+                                className="h-3.5 w-3.5"
+                              />
                             </button>
                           ) : null}
                           <button
@@ -869,7 +919,10 @@ export function EndpointsSection({
                             title={t("common.edit")}
                             className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted"
                           >
-                            <PencilIcon aria-hidden="true" className="h-3.5 w-3.5" />
+                            <PencilIcon
+                              aria-hidden="true"
+                              className="h-3.5 w-3.5"
+                            />
                           </button>
                           <button
                             type="button"
@@ -878,7 +931,10 @@ export function EndpointsSection({
                             title={t("common.delete")}
                             className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-red-500 hover:bg-red-500/5"
                           >
-                            <Trash2Icon aria-hidden="true" className="h-3.5 w-3.5" />
+                            <Trash2Icon
+                              aria-hidden="true"
+                              className="h-3.5 w-3.5"
+                            />
                           </button>
                         </div>
                       </div>

--- a/apps/desktop/src/renderer/components/settings/ai-workbench/constants.ts
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/constants.ts
@@ -114,6 +114,7 @@ export const PROVIDER_OPTIONS: ProviderOption[] = [
   {
     id: "atlascloud",
     name: "Atlas Cloud",
+    labelKey: "settings.aiWorkbenchProviderAtlasCloud",
     defaultUrl: "https://api.atlascloud.ai/v1",
     recommendedProtocol: "openai",
     allowsCustomProtocol: false,

--- a/apps/desktop/src/renderer/components/settings/ai-workbench/constants.ts
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/constants.ts
@@ -113,8 +113,9 @@ export const PROVIDER_OPTIONS: ProviderOption[] = [
   },
   {
     id: "atlascloud",
-    name: "Atlas Cloud",
+    name: "atlascloud",
     labelKey: "settings.aiWorkbenchProviderAtlasCloud",
+    labelDefault: "Atlas Cloud",
     defaultUrl: "https://api.atlascloud.ai/v1",
     recommendedProtocol: "openai",
     allowsCustomProtocol: false,

--- a/apps/desktop/src/renderer/components/settings/ai-workbench/constants.ts
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/constants.ts
@@ -112,6 +112,14 @@ export const PROVIDER_OPTIONS: ProviderOption[] = [
     iconCategory: "Qwen",
   },
   {
+    id: "atlascloud",
+    name: "Atlas Cloud",
+    defaultUrl: "https://api.atlascloud.ai/v1",
+    recommendedProtocol: "openai",
+    allowsCustomProtocol: false,
+    iconCategory: "Atlas Cloud",
+  },
+  {
     id: "doubao",
     name: "豆包",
     defaultUrl: "https://ark.cn-beijing.volces.com/api",

--- a/apps/desktop/src/renderer/components/settings/ai-workbench/helpers.ts
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/helpers.ts
@@ -266,7 +266,10 @@ export function getProviderDisplayLabel(
   const provider = getProviderInfo(providerId);
   return provider
     ? getProviderDisplayName(provider, t)
-    : providerId || "Unknown";
+    : providerId ||
+        t("settings.aiWorkbenchUnknownProvider", {
+          defaultValue: "Unknown provider",
+        });
 }
 
 export function getEndpointDisplayName(input: {

--- a/apps/desktop/src/renderer/components/settings/ai-workbench/helpers.ts
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/helpers.ts
@@ -244,7 +244,8 @@ export function getProviderInfo(
 }
 
 export function getProviderLabel(providerId: string): string {
-  return getProviderInfo(providerId)?.name || providerId || "Unknown";
+  const provider = getProviderInfo(providerId);
+  return provider?.labelDefault || provider?.name || providerId || "Unknown";
 }
 
 export function getProviderDisplayName(
@@ -252,7 +253,9 @@ export function getProviderDisplayName(
   t: TFunction,
 ): string {
   return provider.labelKey
-    ? t(provider.labelKey, { defaultValue: provider.name })
+    ? t(provider.labelKey, {
+        defaultValue: provider.labelDefault || provider.name,
+      })
     : provider.name;
 }
 

--- a/apps/desktop/src/renderer/components/settings/ai-workbench/helpers.ts
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/helpers.ts
@@ -1,3 +1,5 @@
+import type { TFunction } from "i18next";
+
 import type {
   AIModelConfig,
   ChatModelParams,
@@ -245,11 +247,40 @@ export function getProviderLabel(providerId: string): string {
   return getProviderInfo(providerId)?.name || providerId || "Unknown";
 }
 
+export function getProviderDisplayName(
+  provider: ProviderOption,
+  t: TFunction,
+): string {
+  return provider.labelKey
+    ? t(provider.labelKey, { defaultValue: provider.name })
+    : provider.name;
+}
+
+export function getProviderDisplayLabel(
+  providerId: string,
+  t: TFunction,
+): string {
+  const provider = getProviderInfo(providerId);
+  return provider
+    ? getProviderDisplayName(provider, t)
+    : providerId || "Unknown";
+}
+
 export function getEndpointDisplayName(input: {
   name?: string;
   provider: string;
 }): string {
   return input.name?.trim() || getProviderLabel(input.provider);
+}
+
+export function getEndpointDisplayLabel(
+  input: {
+    name?: string;
+    provider: string;
+  },
+  t: TFunction,
+): string {
+  return input.name?.trim() || getProviderDisplayLabel(input.provider, t);
 }
 
 export function getProviderIconCategory(providerId: string): string {

--- a/apps/desktop/src/renderer/components/settings/ai-workbench/helpers.ts
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/helpers.ts
@@ -113,6 +113,9 @@ const MODEL_CATEGORY_CONFIG: Array<{
 ];
 
 const PROVIDER_CATEGORY_MAP: Record<string, string> = {
+  atlas: "Atlas Cloud",
+  atlascloud: "Atlas Cloud",
+  "atlas-cloud": "Atlas Cloud",
   openai: "GPT",
   "openai-responses": "GPT",
   "azure-openai": "GPT",
@@ -444,12 +447,9 @@ export function inferModelAttributes(
     "grok-3",
     "grok-4",
   ].some((keyword) => normalized.includes(keyword));
-  const hasWebSearch = [
-    "search",
-    "sonar",
-    "perplexity",
-    "grok",
-  ].some((keyword) => normalized.includes(keyword));
+  const hasWebSearch = ["search", "sonar", "perplexity", "grok"].some(
+    (keyword) => normalized.includes(keyword),
+  );
 
   return {
     type: "chat",

--- a/apps/desktop/src/renderer/components/settings/ai-workbench/model-form/AvailableModelsList.tsx
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/model-form/AvailableModelsList.tsx
@@ -9,6 +9,7 @@ import { applyModelIdToForm, getModelCategory } from "../helpers";
 import type { ModelFormState } from "../types";
 
 const CATEGORY_ORDER = [
+  "Atlas Cloud",
   "GPT",
   "Claude",
   "Gemini",

--- a/apps/desktop/src/renderer/components/settings/ai-workbench/model-form/AvailableModelsList.tsx
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/model-form/AvailableModelsList.tsx
@@ -98,6 +98,11 @@ export function AvailableModelsList({
     if (category === "Other") {
       return t("settings.other");
     }
+    if (category === "Atlas Cloud") {
+      return t("settings.aiWorkbenchProviderAtlasCloud", {
+        defaultValue: "Atlas Cloud",
+      });
+    }
     return category;
   };
 

--- a/apps/desktop/src/renderer/components/settings/ai-workbench/model-form/BaseFields.tsx
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/model-form/BaseFields.tsx
@@ -25,7 +25,7 @@ import { Select } from "../../../ui/Select";
 import { getCategoryIcon } from "../../../ui/ModelIcons";
 import { PasswordInput } from "../../shared";
 import { PROVIDER_OPTIONS } from "../constants";
-import { getProviderInfo } from "../helpers";
+import { getProviderDisplayName, getProviderInfo } from "../helpers";
 import type { ModelFormState } from "../types";
 
 function CapabilityCheckbox({
@@ -162,18 +162,21 @@ export function BaseFields({
     [modelForm.provider],
   );
   const showProtocolField = providerInfo?.allowsCustomProtocol === true;
-  const providerOptions = PROVIDER_OPTIONS.map((item) => ({
-    value: item.id,
-    label: (
-      <span className="flex min-w-0 items-center gap-2">
-        <span aria-hidden="true" className="shrink-0">
-          {getCategoryIcon(item.iconCategory, 18)}
+  const providerOptions = PROVIDER_OPTIONS.map((item) => {
+    const providerName = getProviderDisplayName(item, t);
+    return {
+      value: item.id,
+      label: (
+        <span className="flex min-w-0 items-center gap-2">
+          <span aria-hidden="true" className="shrink-0">
+            {getCategoryIcon(item.iconCategory, 18)}
+          </span>
+          <span className="truncate">{providerName}</span>
         </span>
-        <span className="truncate">{item.name}</span>
-      </span>
-    ),
-    labelText: item.name,
-  }));
+      ),
+      labelText: providerName,
+    };
+  });
 
   return (
     <>
@@ -386,14 +389,14 @@ export function BaseFields({
             title={t("settings.imageModel")}
             description={t("settings.aiWorkbenchRouteImageGenerationDesc")}
             onChange={(checked) => {
-                setModelForm((prev) => ({
-                  ...prev,
-                  type: checked ? "image" : "chat",
-                  capabilities: {
-                    ...prev.capabilities,
-                    imageGeneration: checked,
-                  },
-                }));
+              setModelForm((prev) => ({
+                ...prev,
+                type: checked ? "image" : "chat",
+                capabilities: {
+                  ...prev.capabilities,
+                  imageGeneration: checked,
+                },
+              }));
             }}
           />
 
@@ -406,14 +409,14 @@ export function BaseFields({
             title={t("settings.aiWorkbenchVisionCapability")}
             description={t("settings.aiWorkbenchVisionCapabilityDesc")}
             onChange={(checked) => {
-                setModelForm((prev) => ({
-                  ...prev,
-                  capabilities: {
-                    ...prev.capabilities,
-                    chat: true,
-                    vision: checked,
-                  },
-                }));
+              setModelForm((prev) => ({
+                ...prev,
+                capabilities: {
+                  ...prev.capabilities,
+                  chat: true,
+                  vision: checked,
+                },
+              }));
             }}
           />
 
@@ -426,14 +429,14 @@ export function BaseFields({
             title={t("settings.aiWorkbenchReasoningCapability")}
             description={t("settings.aiWorkbenchReasoningCapabilityDesc")}
             onChange={(checked) => {
-                setModelForm((prev) => ({
-                  ...prev,
-                  capabilities: {
-                    ...prev.capabilities,
-                    chat: true,
-                    reasoning: checked,
-                  },
-                }));
+              setModelForm((prev) => ({
+                ...prev,
+                capabilities: {
+                  ...prev.capabilities,
+                  chat: true,
+                  reasoning: checked,
+                },
+              }));
             }}
           />
         </div>

--- a/apps/desktop/src/renderer/components/settings/ai-workbench/types.ts
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/types.ts
@@ -10,6 +10,7 @@ import type {
 export type ProviderOption = {
   id: string;
   name: string;
+  labelKey?: string;
   defaultUrl: string;
   recommendedProtocol: AIProtocol;
   allowsCustomProtocol: boolean;

--- a/apps/desktop/src/renderer/components/settings/ai-workbench/types.ts
+++ b/apps/desktop/src/renderer/components/settings/ai-workbench/types.ts
@@ -11,6 +11,7 @@ export type ProviderOption = {
   id: string;
   name: string;
   labelKey?: string;
+  labelDefault?: string;
   defaultUrl: string;
   recommendedProtocol: AIProtocol;
   allowsCustomProtocol: boolean;

--- a/apps/desktop/src/renderer/components/ui/ModelIcons.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelIcons.tsx
@@ -93,10 +93,7 @@ function renderSpecialCategoryIcon(
   }
 
   const className = SPECIAL_CATEGORY_ICON_CLASS[category];
-  const IconComponent = iconConfig.Icon as React.ElementType<{
-    size: number;
-    strokeWidth: number;
-  }>;
+  const IconComponent = iconConfig.Icon;
   const style =
     SPECIAL_CATEGORY_ICON_STYLE[category] ?? SPECIAL_CATEGORY_ICON_STYLE.Other;
   return (

--- a/apps/desktop/src/renderer/components/ui/ModelIcons.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelIcons.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { CircleDotDashedIcon, SlidersHorizontalIcon } from "lucide-react";
+import {
+  CircleDotDashedIcon,
+  CloudIcon,
+  SlidersHorizontalIcon,
+} from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 // AI model provider icon component
@@ -44,6 +48,7 @@ const CATEGORY_ICON_SRC: Record<string, string> = {
 };
 
 const SPECIAL_CATEGORY_ICON: Record<string, LucideIcon> = {
+  "Atlas Cloud": CloudIcon,
   Custom: SlidersHorizontalIcon,
   Other: CircleDotDashedIcon,
 };
@@ -56,6 +61,11 @@ const SPECIAL_CATEGORY_ICON_STYLE: Record<
     background: "linear-gradient(135deg, #eef2ff 0%, #dbeafe 100%)",
     color: "#2563eb",
     border: "1px solid rgba(37,99,235,0.18)",
+  },
+  "Atlas Cloud": {
+    background: "linear-gradient(135deg, #ecfeff 0%, #dbeafe 100%)",
+    color: "#0e7490",
+    border: "1px solid rgba(14,116,144,0.18)",
   },
   Other: {
     background: "linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%)",

--- a/apps/desktop/src/renderer/components/ui/ModelIcons.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelIcons.tsx
@@ -47,10 +47,18 @@ const CATEGORY_ICON_SRC: Record<string, string> = {
   ERNIE: "", // Placeholder for ERNIE
 };
 
-const SPECIAL_CATEGORY_ICON: Record<string, LucideIcon> = {
-  "Atlas Cloud": CloudIcon,
-  Custom: SlidersHorizontalIcon,
-  Other: CircleDotDashedIcon,
+const SPECIAL_CATEGORY_ICON: Record<
+  string,
+  { Icon: LucideIcon; iconName: string }
+> = {
+  "Atlas Cloud": { Icon: CloudIcon, iconName: "CloudIcon" },
+  Custom: { Icon: SlidersHorizontalIcon, iconName: "SlidersHorizontalIcon" },
+  Other: { Icon: CircleDotDashedIcon, iconName: "CircleDotDashedIcon" },
+};
+
+const SPECIAL_CATEGORY_ICON_CLASS: Record<string, string> = {
+  "Atlas Cloud":
+    "border border-cyan-700/20 bg-gradient-to-br from-cyan-50 to-blue-100 text-cyan-700 dark:border-cyan-300/25 dark:from-cyan-950/80 dark:to-blue-950/70 dark:text-cyan-200",
 };
 
 const SPECIAL_CATEGORY_ICON_STYLE: Record<
@@ -61,11 +69,6 @@ const SPECIAL_CATEGORY_ICON_STYLE: Record<
     background: "linear-gradient(135deg, #eef2ff 0%, #dbeafe 100%)",
     color: "#2563eb",
     border: "1px solid rgba(37,99,235,0.18)",
-  },
-  "Atlas Cloud": {
-    background: "linear-gradient(135deg, #ecfeff 0%, #dbeafe 100%)",
-    color: "#0e7490",
-    border: "1px solid rgba(14,116,144,0.18)",
   },
   Other: {
     background: "linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%)",
@@ -84,31 +87,49 @@ function renderSpecialCategoryIcon(
   category: string,
   size: number,
 ): React.ReactNode {
-  const Icon = SPECIAL_CATEGORY_ICON[category];
-  if (!Icon) {
+  const iconConfig = SPECIAL_CATEGORY_ICON[category];
+  if (!iconConfig) {
     return null;
   }
 
+  const className = SPECIAL_CATEGORY_ICON_CLASS[category];
+  const IconComponent = iconConfig.Icon as React.ElementType<{
+    size: number;
+    strokeWidth: number;
+  }>;
   const style =
     SPECIAL_CATEGORY_ICON_STYLE[category] ?? SPECIAL_CATEGORY_ICON_STYLE.Other;
   return (
     <div
       data-category-icon={category}
-      style={{
-        width: size,
-        height: size,
-        borderRadius: 6,
-        background: style.background,
-        border: style.border,
-        color: style.color,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        flexShrink: 0,
-        boxShadow: "0 1px 2px rgba(15,23,42,0.06)",
-      }}
+      data-category-icon-name={iconConfig.iconName}
+      className={
+        className
+          ? `flex shrink-0 items-center justify-center rounded-md shadow-sm ${className}`
+          : undefined
+      }
+      style={
+        className
+          ? {
+              width: size,
+              height: size,
+            }
+          : {
+              width: size,
+              height: size,
+              borderRadius: 6,
+              background: style.background,
+              border: style.border,
+              color: style.color,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexShrink: 0,
+              boxShadow: "0 1px 2px rgba(15,23,42,0.06)",
+            }
+      }
     >
-      <Icon size={size * 0.68} strokeWidth={2.2} />
+      <IconComponent size={size * 0.68} strokeWidth={2.2} />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/i18n/locales/de.json
+++ b/apps/desktop/src/renderer/i18n/locales/de.json
@@ -1355,6 +1355,7 @@
     "aiWorkbenchProviderDisplayName": "Anbietername",
     "aiWorkbenchProviderDisplayNamePlaceholder": "Z.B.: Work OpenAI, New API",
     "aiWorkbenchProviderType": "Anbietertyp",
+    "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
     "aiWorkbenchProviderTypeHint": "Verwendet das Protokoll-Preset und die Endpoint-Regeln von {{type}}.",
     "modelName": "Modellname",
     "modelNamePlaceholder": "Z.B.: gpt-4o, deepseek-chat",

--- a/apps/desktop/src/renderer/i18n/locales/de.json
+++ b/apps/desktop/src/renderer/i18n/locales/de.json
@@ -1356,6 +1356,7 @@
     "aiWorkbenchProviderDisplayNamePlaceholder": "Z.B.: Work OpenAI, New API",
     "aiWorkbenchProviderType": "Anbietertyp",
     "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
+    "aiWorkbenchUnknownProvider": "Unbekannter Anbieter",
     "aiWorkbenchProviderTypeHint": "Verwendet das Protokoll-Preset und die Endpoint-Regeln von {{type}}.",
     "modelName": "Modellname",
     "modelNamePlaceholder": "Z.B.: gpt-4o, deepseek-chat",

--- a/apps/desktop/src/renderer/i18n/locales/en.json
+++ b/apps/desktop/src/renderer/i18n/locales/en.json
@@ -1358,6 +1358,7 @@
     "aiWorkbenchProviderDisplayNamePlaceholder": "e.g., Work OpenAI, New API",
     "aiWorkbenchProviderType": "Provider Type",
     "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
+    "aiWorkbenchUnknownProvider": "Unknown provider",
     "aiWorkbenchProviderTypeHint": "Uses {{type}} protocol preset and endpoint rules.",
     "modelName": "Model Name",
     "modelNamePlaceholder": "e.g., gpt-4o, deepseek-chat",

--- a/apps/desktop/src/renderer/i18n/locales/en.json
+++ b/apps/desktop/src/renderer/i18n/locales/en.json
@@ -1357,6 +1357,7 @@
     "aiWorkbenchProviderDisplayName": "Provider Name",
     "aiWorkbenchProviderDisplayNamePlaceholder": "e.g., Work OpenAI, New API",
     "aiWorkbenchProviderType": "Provider Type",
+    "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
     "aiWorkbenchProviderTypeHint": "Uses {{type}} protocol preset and endpoint rules.",
     "modelName": "Model Name",
     "modelNamePlaceholder": "e.g., gpt-4o, deepseek-chat",

--- a/apps/desktop/src/renderer/i18n/locales/es.json
+++ b/apps/desktop/src/renderer/i18n/locales/es.json
@@ -1355,6 +1355,7 @@
     "aiWorkbenchProviderDisplayName": "Nombre del proveedor",
     "aiWorkbenchProviderDisplayNamePlaceholder": "Ej: OpenAI trabajo, New API",
     "aiWorkbenchProviderType": "Tipo de proveedor",
+    "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
     "aiWorkbenchProviderTypeHint": "Usa el preajuste de protocolo y las reglas de endpoint de {{type}}.",
     "modelName": "Nombre del modelo",
     "modelNamePlaceholder": "Ej: gpt-4o, deepseek-chat",

--- a/apps/desktop/src/renderer/i18n/locales/es.json
+++ b/apps/desktop/src/renderer/i18n/locales/es.json
@@ -1356,6 +1356,7 @@
     "aiWorkbenchProviderDisplayNamePlaceholder": "Ej: OpenAI trabajo, New API",
     "aiWorkbenchProviderType": "Tipo de proveedor",
     "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
+    "aiWorkbenchUnknownProvider": "Proveedor desconocido",
     "aiWorkbenchProviderTypeHint": "Usa el preajuste de protocolo y las reglas de endpoint de {{type}}.",
     "modelName": "Nombre del modelo",
     "modelNamePlaceholder": "Ej: gpt-4o, deepseek-chat",

--- a/apps/desktop/src/renderer/i18n/locales/fr.json
+++ b/apps/desktop/src/renderer/i18n/locales/fr.json
@@ -1357,6 +1357,7 @@
     "aiWorkbenchProviderDisplayNamePlaceholder": "Ex: OpenAI travail, New API",
     "aiWorkbenchProviderType": "Type de fournisseur",
     "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
+    "aiWorkbenchUnknownProvider": "Fournisseur inconnu",
     "aiWorkbenchProviderTypeHint": "Utilise le préréglage de protocole et les règles d'endpoint {{type}}.",
     "modelName": "Nom du modèle",
     "modelNamePlaceholder": "Ex: gpt-4o, deepseek-chat",

--- a/apps/desktop/src/renderer/i18n/locales/fr.json
+++ b/apps/desktop/src/renderer/i18n/locales/fr.json
@@ -1356,6 +1356,7 @@
     "aiWorkbenchProviderDisplayName": "Nom du fournisseur",
     "aiWorkbenchProviderDisplayNamePlaceholder": "Ex: OpenAI travail, New API",
     "aiWorkbenchProviderType": "Type de fournisseur",
+    "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
     "aiWorkbenchProviderTypeHint": "Utilise le préréglage de protocole et les règles d'endpoint {{type}}.",
     "modelName": "Nom du modèle",
     "modelNamePlaceholder": "Ex: gpt-4o, deepseek-chat",

--- a/apps/desktop/src/renderer/i18n/locales/ja.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja.json
@@ -1355,6 +1355,7 @@
     "aiWorkbenchProviderDisplayName": "プロバイダー名",
     "aiWorkbenchProviderDisplayNamePlaceholder": "例：Work OpenAI、New API",
     "aiWorkbenchProviderType": "プロバイダー種別",
+    "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
     "aiWorkbenchProviderTypeHint": "{{type}} のプロトコルプリセットとエンドポイント規則を使用します。",
     "modelName": "モデル名",
     "modelNamePlaceholder": "例：gpt-4o、deepseek-chat",

--- a/apps/desktop/src/renderer/i18n/locales/ja.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja.json
@@ -1356,6 +1356,7 @@
     "aiWorkbenchProviderDisplayNamePlaceholder": "例：Work OpenAI、New API",
     "aiWorkbenchProviderType": "プロバイダー種別",
     "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
+    "aiWorkbenchUnknownProvider": "不明なプロバイダー",
     "aiWorkbenchProviderTypeHint": "{{type}} のプロトコルプリセットとエンドポイント規則を使用します。",
     "modelName": "モデル名",
     "modelNamePlaceholder": "例：gpt-4o、deepseek-chat",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -1356,6 +1356,7 @@
     "aiWorkbenchProviderDisplayNamePlaceholder": "例如：工作 OpenAI、New API",
     "aiWorkbenchProviderType": "供應商類型",
     "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
+    "aiWorkbenchUnknownProvider": "未知供應商",
     "aiWorkbenchProviderTypeHint": "使用 {{type}} 的協定預設與位址規則。",
     "modelName": "模型名稱",
     "modelNamePlaceholder": "例如：gpt-4o、deepseek-chat",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -1355,6 +1355,7 @@
     "aiWorkbenchProviderDisplayName": "供應商名稱",
     "aiWorkbenchProviderDisplayNamePlaceholder": "例如：工作 OpenAI、New API",
     "aiWorkbenchProviderType": "供應商類型",
+    "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
     "aiWorkbenchProviderTypeHint": "使用 {{type}} 的協定預設與位址規則。",
     "modelName": "模型名稱",
     "modelNamePlaceholder": "例如：gpt-4o、deepseek-chat",

--- a/apps/desktop/src/renderer/i18n/locales/zh.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh.json
@@ -1357,6 +1357,7 @@
     "aiWorkbenchProviderDisplayName": "供应商名称",
     "aiWorkbenchProviderDisplayNamePlaceholder": "例如：工作 OpenAI、新 API",
     "aiWorkbenchProviderType": "供应商类型",
+    "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
     "aiWorkbenchProviderTypeHint": "使用 {{type}} 的协议预设与地址规则。",
     "modelName": "模型名称",
     "modelNamePlaceholder": "例如：gpt-4o、deepseek-chat",

--- a/apps/desktop/src/renderer/i18n/locales/zh.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh.json
@@ -1358,6 +1358,7 @@
     "aiWorkbenchProviderDisplayNamePlaceholder": "例如：工作 OpenAI、新 API",
     "aiWorkbenchProviderType": "供应商类型",
     "aiWorkbenchProviderAtlasCloud": "Atlas Cloud",
+    "aiWorkbenchUnknownProvider": "未知供应商",
     "aiWorkbenchProviderTypeHint": "使用 {{type}} 的协议预设与地址规则。",
     "modelName": "模型名称",
     "modelNamePlaceholder": "例如：gpt-4o、deepseek-chat",

--- a/apps/desktop/tests/unit/components/ai-workbench-base-fields.test.tsx
+++ b/apps/desktop/tests/unit/components/ai-workbench-base-fields.test.tsx
@@ -87,6 +87,16 @@ describe("BaseFields", () => {
       "new-api",
       "ollama",
     ]);
+    expect(PROVIDER_OPTIONS).toContainEqual(
+      expect.objectContaining({
+        id: "atlascloud",
+        name: "Atlas Cloud",
+        defaultUrl: "https://api.atlascloud.ai/v1",
+        recommendedProtocol: "openai",
+        allowsCustomProtocol: false,
+        iconCategory: "Atlas Cloud",
+      }),
+    );
   });
 
   it("keeps every preset provider on a dedicated icon instead of a letter fallback", () => {
@@ -104,11 +114,46 @@ describe("BaseFields", () => {
       "Llama",
       "Grok",
       "Qwen",
+      "Atlas Cloud",
     ]) {
       const { container, unmount } = render(<>{getCategoryIcon(category)}</>);
-      expect(container.querySelector(`img[alt="${category}"]`)).not.toBeNull();
+      if (category === "Atlas Cloud") {
+        expect(
+          container.querySelector('[data-category-icon="Atlas Cloud"]'),
+        ).not.toBeNull();
+      } else {
+        expect(
+          container.querySelector(`img[alt="${category}"]`),
+        ).not.toBeNull();
+      }
       unmount();
     }
+  });
+
+  it("prefills Atlas Cloud as an OpenAI-compatible endpoint preset", async () => {
+    const setModelForm = vi.fn();
+
+    await renderWithI18n(
+      <BaseFields
+        modelForm={createModelForm("custom")}
+        setModelForm={setModelForm}
+        fetchingModels={false}
+        onFetchModels={() => undefined}
+      />,
+      { language: "en" },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Provider" }));
+    fireEvent.click(await screen.findByRole("option", { name: "Atlas Cloud" }));
+
+    expect(setModelForm).toHaveBeenCalledWith(expect.any(Function));
+    const updater = setModelForm.mock.calls.at(-1)?.[0];
+    expect(typeof updater).toBe("function");
+    expect(updater(createModelForm("custom"))).toMatchObject({
+      provider: "atlascloud",
+      apiProtocol: "openai",
+      apiUrl: "https://api.atlascloud.ai/v1",
+    });
   });
 
   it("shows protocol selection for providers that support custom protocols", async () => {
@@ -230,11 +275,7 @@ describe("BaseFields", () => {
       { language: "en" },
     );
 
-    for (const label of [
-      "Image generation",
-      "Vision input",
-      "Reasoning",
-    ]) {
+    for (const label of ["Image generation", "Vision input", "Reasoning"]) {
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     }
 

--- a/apps/desktop/tests/unit/components/ai-workbench-base-fields.test.tsx
+++ b/apps/desktop/tests/unit/components/ai-workbench-base-fields.test.tsx
@@ -5,6 +5,10 @@ import { describe, expect, it, vi } from "vitest";
 import { BaseFields } from "../../../src/renderer/components/settings/ai-workbench/model-form/BaseFields";
 import { PROVIDER_OPTIONS } from "../../../src/renderer/components/settings/ai-workbench/constants";
 import {
+  getEndpointCategory,
+  getProviderIconCategory,
+} from "../../../src/renderer/components/settings/ai-workbench/helpers";
+import {
   getCategoryIcon,
   hasDedicatedCategoryIcon,
 } from "../../../src/renderer/components/ui/ModelIcons";
@@ -91,6 +95,7 @@ describe("BaseFields", () => {
       expect.objectContaining({
         id: "atlascloud",
         name: "Atlas Cloud",
+        labelKey: "settings.aiWorkbenchProviderAtlasCloud",
         defaultUrl: "https://api.atlascloud.ai/v1",
         recommendedProtocol: "openai",
         allowsCustomProtocol: false,
@@ -118,9 +123,15 @@ describe("BaseFields", () => {
     ]) {
       const { container, unmount } = render(<>{getCategoryIcon(category)}</>);
       if (category === "Atlas Cloud") {
-        expect(
-          container.querySelector('[data-category-icon="Atlas Cloud"]'),
-        ).not.toBeNull();
+        const atlasIcon = container.querySelector(
+          '[data-category-icon="Atlas Cloud"]',
+        );
+        expect(atlasIcon).not.toBeNull();
+        expect(atlasIcon).toHaveAttribute(
+          "data-category-icon-name",
+          "CloudIcon",
+        );
+        expect(atlasIcon).toHaveClass("dark:text-cyan-200");
       } else {
         expect(
           container.querySelector(`img[alt="${category}"]`),
@@ -128,6 +139,16 @@ describe("BaseFields", () => {
       }
       unmount();
     }
+  });
+
+  it("maps Atlas Cloud aliases to the dedicated endpoint and provider icon category", () => {
+    for (const provider of ["atlas", "atlascloud", "atlas-cloud"]) {
+      expect(getProviderIconCategory(provider)).toBe("Atlas Cloud");
+      expect(getEndpointCategory(provider, [])).toBe("Atlas Cloud");
+    }
+
+    expect(getProviderIconCategory("unknown-provider")).toBe("Other");
+    expect(getEndpointCategory("unknown-provider", [])).toBe("Other");
   });
 
   it("prefills Atlas Cloud as an OpenAI-compatible endpoint preset", async () => {

--- a/apps/desktop/tests/unit/components/ai-workbench-base-fields.test.tsx
+++ b/apps/desktop/tests/unit/components/ai-workbench-base-fields.test.tsx
@@ -94,8 +94,9 @@ describe("BaseFields", () => {
     expect(PROVIDER_OPTIONS).toContainEqual(
       expect.objectContaining({
         id: "atlascloud",
-        name: "Atlas Cloud",
+        name: "atlascloud",
         labelKey: "settings.aiWorkbenchProviderAtlasCloud",
+        labelDefault: "Atlas Cloud",
         defaultUrl: "https://api.atlascloud.ai/v1",
         recommendedProtocol: "openai",
         allowsCustomProtocol: false,

--- a/packages/core/tests/ai-protocol.test.ts
+++ b/packages/core/tests/ai-protocol.test.ts
@@ -32,10 +32,23 @@ describe("shared AI protocol derivation", () => {
       "https://api.anthropic.com",
       "https://api.anthropic.com/v1/messages",
     ],
+    [
+      "openai",
+      "https://api.atlascloud.ai/v1",
+      "https://api.atlascloud.ai/v1/chat/completions",
+    ],
   ] as const)("builds the %s chat endpoint", (protocol, input, expected) => {
     expect(
       buildChatEndpointFromBase(resolveProtocolBase(input, protocol)),
     ).toBe(expected);
+  });
+
+  it("builds the Atlas Cloud OpenAI-compatible model discovery endpoint", () => {
+    expect(
+      buildModelsEndpointFromBase(
+        resolveProtocolBase("https://api.atlascloud.ai/v1", "openai"),
+      ),
+    ).toBe("https://api.atlascloud.ai/v1/models");
   });
 
   it("treats a trailing hash as an exact final endpoint on every surface", () => {

--- a/spec/knowledge/reference/ai-provider-apis.md
+++ b/spec/knowledge/reference/ai-provider-apis.md
@@ -60,6 +60,7 @@
 | Moonshot / Kimi | `https://api.moonshot.cn` | SDK base URL commonly `https://api.moonshot.cn/v1` | `Authorization: Bearer` | `POST /v1/chat/completions` | not separately confirmed in this pass | PromptHub 默认 host 不含 `/v1`，传输层自动补齐 `/v1/chat/completions` | Officially documented (partial) |
 | 智谱 AI / BigModel | `https://open.bigmodel.cn/api/paas` | OpenAI compat examples use `https://open.bigmodel.cn/api/paas/v4/` | OpenAI SDK compat with API key / bearer-style auth | `POST /chat/completions` under `/api/paas/v4/` | not separately confirmed in this pass | PromptHub 默认 host 缺少 `/v4`，当前 generic `/v1/chat/completions` 归一化与官方 compat 文档不完全一致 | Officially documented (partial) |
 | 阿里百炼 / Qwen (DashScope) | `https://dashscope.aliyuncs.com/compatible-mode` | OpenAI compat SDK base URL commonly `https://dashscope.aliyuncs.com/compatible-mode/v1` | `Authorization: Bearer` | `POST /compatible-mode/v1/chat/completions` | not separately confirmed in this pass | PromptHub 默认 host 不含 `/v1`，传输层负责自动补齐 | Officially documented |
+| Atlas Cloud | `https://api.atlascloud.ai/v1` | `https://api.atlascloud.ai/v1` | `Authorization: Bearer` | `POST /chat/completions` | `GET /models` | PromptHub 作为 OpenAI-compatible provider preset，保存 `/v1` base URL 并由共享传输层构造 chat/model endpoints | Live catalog verified |
 | 豆包 / Ark | `https://ark.cn-beijing.volces.com/api` | Data plane: `https://ark.cn-beijing.volces.com/api/v3`; Control plane: `https://ark.cn-beijing.volcengineapi.com/` | Data plane: `Authorization: Bearer`; Control plane uses HMAC auth | `POST /chat/completions` | not confirmed in this pass | PromptHub 默认 host 缺少 `/v3`，当前 generic `/v1/chat/completions` 建模与官方数据面接口不一致 | Officially documented (partial) |
 | 文心一言 / Qianfan | `https://qianfan.baidubce.com/v2` | `https://qianfan.baidubce.com/v2` | `Authorization: Bearer` | `POST /chat/completions` | `GET /models` | PromptHub 默认 host 已含 `/v2`，renderer / main 当前都会直接补成 `/chat/completions` 与 `/models`，与本轮官方 OpenAI-compatible 文档一致 | Officially documented |
 | 讯飞星火 | `https://spark-api-open.xf-yun.com` | OpenAI SDK compat base URL `https://spark-api-open.xf-yun.com/v1/` | `Authorization: Bearer <APIPassword>` | `POST /v1/chat/completions` | not confirmed in this pass | PromptHub 默认 host 不含 `/v1`，传输层会自动补齐 | Officially documented (partial) |
@@ -82,6 +83,7 @@
 | OpenRouter | no | `https://openrouter.ai/api/v1` | `Authorization: Bearer` | `POST /chat/completions` | 多模型路由平台，不是单一模型厂商；也支持 OpenAI SDK 指向其 `api/v1` base URL | Officially documented |
 | SiliconFlow | no | `https://api.siliconflow.cn/v1` | `Authorization: Bearer` | `POST /chat/completions` | 聚合/云平台；官方文档明确采用 OpenAI-compatible chat completions 形态 | Officially documented |
 | ModelScope | no | official API inference platform exists | provider-specific | platform supports API inference, but stable chat endpoint details were not fully captured in this pass | 更像模型平台/推理平台，不应直接等同于某一模型族 | Evidence limited |
+
 ## Common Provider Alias Mapping
 
 下表优先收录御三家与国内主流厂商的常见标签、别名与模型族映射，避免把模型名、英文别名或平台标签误记为独立厂商。
@@ -95,6 +97,7 @@
 | `Moonshot`, `Kimi`, `Kimi k2` | provider / model-family alias | Moonshot / Kimi | `Kimi k2` 是模型族名称，不是新的 provider | Officially documented (partial) |
 | `智谱 AI`, `BigModel`, `GLM`, `Zhipu GLM`, `Zhipu GLM en` | provider / model-family alias | 智谱 AI / BigModel | GLM 家族标签应统一映射回智谱生态 | Officially documented (partial) |
 | `通义千问`, `Qwen`, `DashScope` | provider / model-family / platform alias | 阿里百炼 / Qwen (DashScope) | `Qwen` 是模型族，`DashScope` 是平台入口 | Officially documented |
+| `Atlas Cloud`, `AtlasCloud`, `atlascloud`, `atlas-cloud`, `atlas` | canonical provider / provider alias | Atlas Cloud | Atlas Cloud 是 OpenAI-compatible 聚合平台；模型名仍应按原始 model id 保存，例如 `qwen/qwen3.5-flash` | Live catalog verified |
 | `腾讯混元`, `Hunyuan` | provider / model-family alias | 腾讯混元 / Hunyuan | 国内主流厂商标签；官方提供 OpenAI 兼容接口 | Officially documented |
 | `豆包`, `Doubao`, `Ark`, `DouBaoSeed` | provider / platform / seed-family label | 豆包 / Ark | `Ark` 是官方平台标签；`DouBaoSeed` 仍混合了平台与 Seed 家族命名 | Officially documented (partial) |
 | `文心一言`, `ERNIE`, `Qianfan` | provider / model-family / platform alias | 文心一言 / Qianfan | `Qianfan` 是平台标签，`ERNIE` 更接近模型族名称；PromptHub 当前默认接的是 Qianfan V2 OpenAI-compatible 面 | Officially documented |


### PR DESCRIPTION
## Summary
- Add Atlas Cloud as a built-in AI Workbench provider preset using the OpenAI-compatible base URL https://api.atlascloud.ai/v1.
- Map atlas, atlascloud, and atlas-cloud provider aliases to a dedicated Atlas Cloud category and icon treatment in model lists.
- Add focused tests for the provider preset defaults and shared chat/model endpoint construction, plus a technical provider API reference entry.

## Validation
- corepack pnpm@9.15.0 install --frozen-lockfile --ignore-scripts
- corepack pnpm@9.15.0 --filter @prompthub/desktop exec vitest run tests/unit/components/ai-workbench-base-fields.test.tsx tests/unit/components/available-models-list.test.tsx: 15 tests passed
- corepack pnpm@9.15.0 --filter @prompthub/core exec vitest run tests/ai-protocol.test.ts: 10 tests passed
- ./node_modules/.bin/prettier --check changed TS/TSX test files: passed
- changed-file ESLint: passed
- corepack pnpm@9.15.0 --filter @prompthub/shared typecheck: passed
- corepack pnpm@9.15.0 --filter @prompthub/core typecheck: passed
- git diff --check and git diff --cached --check: passed
- Atlas Cloud live /v1/models catalog returned 121 visible models and confirmed qwen/qwen3.5-flash and deepseek-ai/deepseek-v4-pro

Desktop typecheck note: corepack pnpm@9.15.0 --filter @prompthub/desktop typecheck currently fails in unrelated existing files with React/Lucide JSX type compatibility errors after dependency install, such as src/renderer/App.tsx and multiple src/renderer/components/* files. The focused AI Workbench tests and changed-file ESLint passed.

## README and promotion compliance
No README changes. No logo assets, sponsor copy, credits copy, or partner promotion were added. The only documentation change is the existing technical provider API reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 **Atlas Cloud**（OpenAI 兼容）模型服务提供商，提供内置默认 API 地址；在工作台选择后可自动填充对应提供商、协议与接口。
* **改进**
  * 工作台中 Atlas Cloud 分类与图标样式已增强，并支持本地化展示；端点/提供商的展示文案在界面中保持一致。
* **文档**
  * 更新 Atlas Cloud 的默认配置、端点信息及别名映射说明。
* **测试**
  * 补充 Atlas Cloud 相关接口推导与界面交互用例覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->