### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,10 +605,10 @@ PromptHub 当前采用的是 `spec-init` 文档边界 + `spec/changes/active/<ch
 
 ## Star History
 
-<a href="https://star-history.com/#legeling/PromptHub&Date">
+<a href="https://star-history.dera.page/#legeling/PromptHub&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
-    <img alt="Star History" src="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
+    <img alt="Star History" src="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date" />
   </picture>
 </a>
 

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -546,10 +546,10 @@ Danke an alle, die zu PromptHub beigetragen haben.
 
 ## Star-Verlauf
 
-<a href="https://star-history.com/#legeling/PromptHub&Date">
+<a href="https://star-history.dera.page/#legeling/PromptHub&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
-    <img alt="Star-Verlauf" src="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
+    <img alt="Star-Verlauf" src="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date" />
   </picture>
 </a>
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -580,10 +580,10 @@ Thanks to everyone who has contributed to PromptHub.
 
 ## Star history
 
-<a href="https://star-history.com/#legeling/PromptHub&Date">
+<a href="https://star-history.dera.page/#legeling/PromptHub&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
-    <img alt="Star history" src="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
+    <img alt="Star history" src="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date" />
   </picture>
 </a>
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -546,10 +546,10 @@ Gracias a todas las personas que han contribuido a PromptHub.
 
 ## Historial de stars
 
-<a href="https://star-history.com/#legeling/PromptHub&Date">
+<a href="https://star-history.dera.page/#legeling/PromptHub&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
-    <img alt="Historial de stars" src="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
+    <img alt="Historial de stars" src="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date" />
   </picture>
 </a>
 

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -546,10 +546,10 @@ Merci à toutes celles et ceux qui ont contribué à PromptHub.
 
 ## Star history
 
-<a href="https://star-history.com/#legeling/PromptHub&Date">
+<a href="https://star-history.dera.page/#legeling/PromptHub&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
-    <img alt="Star history" src="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
+    <img alt="Star history" src="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date" />
   </picture>
 </a>
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -546,10 +546,10 @@ PromptHub に貢献してくださったすべての方へ感謝します。
 
 ## Star History
 
-<a href="https://star-history.com/#legeling/PromptHub&Date">
+<a href="https://star-history.dera.page/#legeling/PromptHub&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
-    <img alt="Star History" src="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
+    <img alt="Star History" src="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date" />
   </picture>
 </a>
 

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -548,10 +548,10 @@ PromptHub/
 
 ## Star History
 
-<a href="https://star-history.com/#legeling/PromptHub&Date">
+<a href="https://star-history.dera.page/#legeling/PromptHub&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
-    <img alt="Star History" src="https://api.star-history.com/svg?repos=legeling/PromptHub&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date&theme=dark" />
+    <img alt="Star History" src="https://star-history.dera.page/svg?repos=legeling/PromptHub&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart shown in the README and all localized variants is currently broken and fails to render. This change restores a working chart by pointing the image and its wrapping link to a reliable mirror, keeping the chart visible for readers across all supported languages. The badge links are left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新 Star History 图表的链接和图片来源，统一使用新的服务地址。
  * 同步更新中文、英文、德文、西班牙文、法文、日文及繁体中文文档中的相关链接。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->