### PR TITLE
fix(storage): heal prompt current_version mismatch before canonical publication

### DIFF
--- a/apps/desktop/src/main/ipc/prompt.ipc.ts
+++ b/apps/desktop/src/main/ipc/prompt.ipc.ts
@@ -141,6 +141,10 @@ export function registerPromptIPC(
     return true;
   });
 
+  ipcMain.handle(IPC_CHANNELS.PROMPT_COUNT_TAG_REFERENCES, async (_, tag: string) => {
+    return db.countTagReferences(String(tag ?? ""));
+  });
+
   ipcMain.handle(
     IPC_CHANNELS.PROMPT_UPDATE,
     async (_, id: string, data: UpdatePromptDTO) => {

--- a/apps/desktop/src/main/ipc/prompt.ipc.ts
+++ b/apps/desktop/src/main/ipc/prompt.ipc.ts
@@ -136,13 +136,19 @@ export function registerPromptIPC(
   );
 
   ipcMain.handle(IPC_CHANNELS.PROMPT_DELETE_TAG, async (_, tag: string) => {
-    db.deleteTag(tag);
-    syncWorkspace();
-    return true;
-  });
-
-  ipcMain.handle(IPC_CHANNELS.PROMPT_COUNT_TAG_REFERENCES, async (_, tag: string) => {
-    return db.countTagReferences(String(tag ?? ""));
+    if (typeof tag !== "string" || !tag.trim()) {
+      throw new Error("PROMPT_TAG_DELETE_INVALID_TAG");
+    }
+    try {
+      const result = db.deleteTagIfUnreferenced(tag);
+      if (result.deleted) {
+        syncWorkspace();
+      }
+      return result;
+    } catch (error) {
+      console.error("Failed to delete tag:", error);
+      throw new Error("PROMPT_TAG_DELETE_FAILED");
+    }
   });
 
   ipcMain.handle(

--- a/apps/desktop/src/main/services/canonical-storage-startup.ts
+++ b/apps/desktop/src/main/services/canonical-storage-startup.ts
@@ -193,6 +193,50 @@ function healPromptVersionPointers(sourceDatabasePath: string): void {
   }
 }
 
+/**
+ * Relocate a stale `data/.trash/cache/prompt-workspace` leftover out of the
+ * canonical authority root without deleting it. In canonical-files mode every
+ * file under `data/` must be declared by the Prompt graph manifest (or be a
+ * trusted domain/asset prefix); an old file-workspace snapshot that ended up
+ * nested under the canonical root makes `verifyInventory` fail on every prompt
+ * mutation (`canonical graph file inventory count mismatch`). A non-destructive
+ * move to `<activeRoot>/recovery/...` clears the root while preserving the
+ * archived snapshot for the user. Idempotent: once moved, the source path no
+ * longer exists.
+ *
+ * 把旧版误入 canonical 根的 `data/.trash/cache/prompt-workspace` 快照非破坏地
+ * 搬迁到 recovery 目录再删除 prompt，避免每次 reconcile 时的 inventory mismatch；
+ * 仅当该子路径确实存在时才动作，绝不改动、删除快照内容。
+ */
+export function relocateTrashedPromptWorkspaceFromCanonicalRoot(
+  dataRoot: string,
+  activeRoot: string,
+): void {
+  const leftoverRoot = path.join(
+    dataRoot,
+    ".trash",
+    "cache",
+    "prompt-workspace",
+  );
+  let sourceStat: fs.Stats;
+  try {
+    sourceStat = fs.lstatSync(leftoverRoot);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink()) {
+    return; // not the well-known snapshot dir; leave other shapes untouched
+  }
+  const destRoot = path.join(activeRoot, "recovery", "canonical-prompt-trash");
+  fs.mkdirSync(destRoot, { recursive: true, mode: 0o700 });
+  const dest = path.join(
+    destRoot,
+    `prompt-workspace-${Date.now()}-${process.pid}`,
+  );
+  fs.renameSync(leftoverRoot, dest);
+}
+
 export async function ensureCanonicalStorageAuthorityOnStartup(
   options: EnsureCanonicalStorageAuthorityOnStartupOptions,
 ): Promise<CanonicalStorageAuthorityStartupResult> {
@@ -209,6 +253,10 @@ export async function ensureCanonicalStorageAuthorityOnStartup(
   }
   await options.prepareSourceDatabase?.();
   healPromptVersionPointers(sourceDatabasePath);
+  relocateTrashedPromptWorkspaceFromCanonicalRoot(
+    path.dirname(sourceDatabasePath),
+    activeRoot,
+  );
   const checkpointPath = path.resolve(
     options.checkpointPath ??
       path.join(

--- a/apps/desktop/src/main/services/canonical-storage-startup.ts
+++ b/apps/desktop/src/main/services/canonical-storage-startup.ts
@@ -11,6 +11,11 @@ import {
 } from "@prompthub/core";
 
 import {
+  DatabaseAdapter,
+  repairPromptVersionConsistency,
+} from "@prompthub/db";
+
+import {
   publishCanonicalStorageAuthority,
   type PublishCanonicalStorageAuthorityOptions,
   type PublishCanonicalStorageAuthorityResult,
@@ -147,6 +152,47 @@ async function ensureExistingCanonicalAuthority(
   }
 }
 
+/**
+ * Best-effort source repair before canonical authority is projected: converge
+ * every prompt's `current_version` onto its stored version history so
+ * `validateVersionSet` no longer aborts startup with a "Prompt resource
+ * current version is missing" error. Only recognized SQLite images are opened;
+ * other/mock file contents are left untouched so unrelated recovery flows keep
+ * their behavior.
+ *
+ * 在投影 canonical authority 前对源库做尽力而为修复：把每个 prompt 的
+ * current_version 收敛到既有版本历史，从而不再因版本缺失中断启动。
+ */
+function healPromptVersionPointers(sourceDatabasePath: string): void {
+  let imagePrefix: Buffer | undefined;
+  try {
+    const descriptor = fs.openSync(sourceDatabasePath, fs.constants.O_RDONLY);
+    try {
+      imagePrefix = Buffer.alloc(16);
+      imagePrefix = imagePrefix.subarray(
+        0,
+        fs.readSync(descriptor, imagePrefix, 0, imagePrefix.length, 0),
+      ) as Buffer;
+    } finally {
+      fs.closeSync(descriptor);
+    }
+  } catch {
+    return;
+  }
+  if (
+    !imagePrefix ||
+    imagePrefix.toString("utf8", 0, 16) !== "SQLite format 3\x00"
+  ) {
+    return;
+  }
+  const database = new DatabaseAdapter(sourceDatabasePath);
+  try {
+    repairPromptVersionConsistency(database);
+  } finally {
+    database.close();
+  }
+}
+
 export async function ensureCanonicalStorageAuthorityOnStartup(
   options: EnsureCanonicalStorageAuthorityOnStartupOptions,
 ): Promise<CanonicalStorageAuthorityStartupResult> {
@@ -162,6 +208,7 @@ export async function ensureCanonicalStorageAuthorityOnStartup(
     return { status: "source-database-missing" };
   }
   await options.prepareSourceDatabase?.();
+  healPromptVersionPointers(sourceDatabasePath);
   const checkpointPath = path.resolve(
     options.checkpointPath ??
       path.join(

--- a/apps/desktop/src/main/services/canonical-storage-startup.ts
+++ b/apps/desktop/src/main/services/canonical-storage-startup.ts
@@ -208,17 +208,40 @@ function healPromptVersionPointers(sourceDatabasePath: string): void {
  * 搬迁到 recovery 目录再删除 prompt，避免每次 reconcile 时的 inventory mismatch；
  * 仅当该子路径确实存在时才动作，绝不改动、删除快照内容。
  */
+/**
+ * Returns true when any already-existing segment under `root` is a symbolic
+ * link or a non-directory. Missing trailing segments are safe (they will be
+ * created as real directories). Used to guarantee relocation never moves a
+ * path that resolves outside the canonical root through a symlink ancestor.
+ */
+function hasUnsafeDirectoryChain(root: string, segments: string[]): boolean {
+  let current = root;
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(current);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+      throw error;
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory()) return true;
+  }
+  return false;
+}
+
 export function relocateTrashedPromptWorkspaceFromCanonicalRoot(
   dataRoot: string,
   activeRoot: string,
 ): void {
-  const leftoverRoot = path.join(
-    dataRoot,
-    ".trash",
-    "cache",
-    "prompt-workspace",
-  );
+  const leftoverSegments = [".trash", "cache", "prompt-workspace"];
+  const leftoverRoot = path.join(dataRoot, ...leftoverSegments);
   try {
+    if (hasUnsafeDirectoryChain(dataRoot, leftoverSegments)) {
+      // A symlinked or non-directory ancestor means leftoverRoot may resolve
+      // outside the canonical root. Never relocate such a path.
+      return;
+    }
     let sourceStat: fs.Stats;
     try {
       sourceStat = fs.lstatSync(leftoverRoot);
@@ -229,11 +252,11 @@ export function relocateTrashedPromptWorkspaceFromCanonicalRoot(
     if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink()) {
       return; // not the well-known snapshot dir; leave other shapes untouched
     }
-    const destRoot = path.join(
-      activeRoot,
-      "recovery",
-      "canonical-prompt-trash",
-    );
+    const destSegments = ["recovery", "canonical-prompt-trash"];
+    if (hasUnsafeDirectoryChain(activeRoot, destSegments)) {
+      return;
+    }
+    const destRoot = path.join(activeRoot, ...destSegments);
     fs.mkdirSync(destRoot, { recursive: true, mode: 0o700 });
     const dest = path.join(
       destRoot,
@@ -256,6 +279,16 @@ export async function ensureCanonicalStorageAuthorityOnStartup(
 ): Promise<CanonicalStorageAuthorityStartupResult> {
   const activeRoot = path.resolve(options.activeRoot);
   if (readCanonicalStorageAuthority(activeRoot)) {
+    // Existing authority: relocate any leftover prompt-workspace snapshot found
+    // under the canonical root. Pure filesystem relocation is safe here; do NOT
+    // open the operational SQLite (an app-held WAL lock must not block startup).
+    const sourceDatabasePath = path.resolve(options.sourceDatabasePath);
+    if (assertRegularDatabaseOrMissing(sourceDatabasePath)) {
+      relocateTrashedPromptWorkspaceFromCanonicalRoot(
+        path.dirname(sourceDatabasePath),
+        activeRoot,
+      );
+    }
     return ensureExistingCanonicalAuthority(options, activeRoot);
   }
   if (!readRendererPersistenceMigrationMarker(activeRoot)) {

--- a/apps/desktop/src/main/services/canonical-storage-startup.ts
+++ b/apps/desktop/src/main/services/canonical-storage-startup.ts
@@ -218,23 +218,37 @@ export function relocateTrashedPromptWorkspaceFromCanonicalRoot(
     "cache",
     "prompt-workspace",
   );
-  let sourceStat: fs.Stats;
   try {
-    sourceStat = fs.lstatSync(leftoverRoot);
+    let sourceStat: fs.Stats;
+    try {
+      sourceStat = fs.lstatSync(leftoverRoot);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+    if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink()) {
+      return; // not the well-known snapshot dir; leave other shapes untouched
+    }
+    const destRoot = path.join(
+      activeRoot,
+      "recovery",
+      "canonical-prompt-trash",
+    );
+    fs.mkdirSync(destRoot, { recursive: true, mode: 0o700 });
+    const dest = path.join(
+      destRoot,
+      `prompt-workspace-${Date.now()}-${process.pid}`,
+    );
+    fs.renameSync(leftoverRoot, dest);
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-    throw error;
+    // Best-effort relocation: a stale snapshot must never block canonical
+    // authority publication (e.g. EACCES on the recovery root or EXDEV across
+    // filesystems). Record the full error and continue startup.
+    console.warn(
+      "[startup] failed to relocate stray canonical prompt-workspace snapshot:",
+      error,
+    );
   }
-  if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink()) {
-    return; // not the well-known snapshot dir; leave other shapes untouched
-  }
-  const destRoot = path.join(activeRoot, "recovery", "canonical-prompt-trash");
-  fs.mkdirSync(destRoot, { recursive: true, mode: 0o700 });
-  const dest = path.join(
-    destRoot,
-    `prompt-workspace-${Date.now()}-${process.pid}`,
-  );
-  fs.renameSync(leftoverRoot, dest);
 }
 
 export async function ensureCanonicalStorageAuthorityOnStartup(

--- a/apps/desktop/src/preload/api/prompt.ts
+++ b/apps/desktop/src/preload/api/prompt.ts
@@ -30,6 +30,8 @@ export const promptApi = {
     ipcRenderer.invoke(IPC_CHANNELS.PROMPT_RENAME_TAG, oldTag, newTag),
   deleteTag: (tag: string) =>
     ipcRenderer.invoke(IPC_CHANNELS.PROMPT_DELETE_TAG, tag),
+  countTagReferences: (tag: string) =>
+    ipcRenderer.invoke(IPC_CHANNELS.PROMPT_COUNT_TAG_REFERENCES, tag) as Promise<number>,
   update: (id: string, data: UpdatePromptDTO) =>
     ipcRenderer.invoke(IPC_CHANNELS.PROMPT_UPDATE, id, data),
   delete: (id: string) => ipcRenderer.invoke(IPC_CHANNELS.PROMPT_DELETE, id),

--- a/apps/desktop/src/preload/api/prompt.ts
+++ b/apps/desktop/src/preload/api/prompt.ts
@@ -28,10 +28,8 @@ export const promptApi = {
   getAllTags: () => ipcRenderer.invoke(IPC_CHANNELS.PROMPT_GET_ALL_TAGS),
   renameTag: (oldTag: string, newTag: string) =>
     ipcRenderer.invoke(IPC_CHANNELS.PROMPT_RENAME_TAG, oldTag, newTag),
-  deleteTag: (tag: string) =>
+  deleteTag: (tag: string): Promise<{ deleted: boolean; referenced: number }> =>
     ipcRenderer.invoke(IPC_CHANNELS.PROMPT_DELETE_TAG, tag),
-  countTagReferences: (tag: string) =>
-    ipcRenderer.invoke(IPC_CHANNELS.PROMPT_COUNT_TAG_REFERENCES, tag) as Promise<number>,
   update: (id: string, data: UpdatePromptDTO) =>
     ipcRenderer.invoke(IPC_CHANNELS.PROMPT_UPDATE, id, data),
   delete: (id: string) => ipcRenderer.invoke(IPC_CHANNELS.PROMPT_DELETE, id),

--- a/apps/desktop/src/renderer/components/prompt/TagManagerModal.tsx
+++ b/apps/desktop/src/renderer/components/prompt/TagManagerModal.tsx
@@ -128,6 +128,21 @@ export function TagManagerModal({
       return;
     }
 
+    if (!isSkillManager) {
+      const referencedBy = await window.api.prompt.countTagReferences(tag);
+      if (referencedBy > 0) {
+        showToast(
+          t('prompt.deleteBlockedByTagReference', {
+            count: referencedBy,
+            defaultValue:
+              'This tag is still used by {{count}} prompt(s) and cannot be deleted while in use.',
+          }),
+          'error',
+        );
+        return;
+      }
+    }
+
     try {
       setProcessingTag(tag);
 

--- a/apps/desktop/src/renderer/components/prompt/TagManagerModal.tsx
+++ b/apps/desktop/src/renderer/components/prompt/TagManagerModal.tsx
@@ -128,21 +128,6 @@ export function TagManagerModal({
       return;
     }
 
-    if (!isSkillManager) {
-      const referencedBy = await window.api.prompt.countTagReferences(tag);
-      if (referencedBy > 0) {
-        showToast(
-          t('prompt.deleteBlockedByTagReference', {
-            count: referencedBy,
-            defaultValue:
-              'This tag is still used by {{count}} prompt(s) and cannot be deleted while in use.',
-          }),
-          'error',
-        );
-        return;
-      }
-    }
-
     try {
       setProcessingTag(tag);
 
@@ -162,7 +147,18 @@ export function TagManagerModal({
           throw new Error(`Failed to delete skill tag: ${tag}`);
         }
       } else {
-        await window.api.prompt.deleteTag(tag);
+        const deleteResult = await window.api.prompt.deleteTag(tag);
+        if (!deleteResult.deleted && deleteResult.referenced > 0) {
+          showToast(
+            t('prompt.deleteBlockedByTagReference', {
+              count: deleteResult.referenced,
+              defaultValue:
+                'This tag is still used by {{count}} prompt(s) and cannot be deleted while in use.',
+            }),
+            'error',
+          );
+          return;
+        }
         deletePromptTagCatalogEntry(tag);
         await fetchPrompts();
         await loadPromptTags();

--- a/apps/desktop/src/renderer/i18n/locales/de.json
+++ b/apps/desktop/src/renderer/i18n/locales/de.json
@@ -49,6 +49,7 @@
   "prompt": {
     "title": "Titel",
     "description": "Beschreibung",
+    "deleteBlockedByTagReference": "Dieses Tag wird noch von {{count}} Prompt(s) verwendet und kann nicht gelöscht werden.",
     "systemPrompt": "System-Prompt",
     "systemPromptEn": "System-Prompt (Englisch)",
     "userPrompt": "Benutzer-Prompt",

--- a/apps/desktop/src/renderer/i18n/locales/en.json
+++ b/apps/desktop/src/renderer/i18n/locales/en.json
@@ -50,6 +50,7 @@
   "prompt": {
     "title": "Title",
     "description": "Description",
+    "deleteBlockedByTagReference": "This tag is still used by {{count}} prompt(s) and cannot be deleted while in use.",
     "systemPrompt": "System Prompt",
     "systemPromptEn": "System Prompt (English)",
     "userPrompt": "User Prompt",

--- a/apps/desktop/src/renderer/i18n/locales/es.json
+++ b/apps/desktop/src/renderer/i18n/locales/es.json
@@ -49,6 +49,7 @@
   "prompt": {
     "title": "Título",
     "description": "Descripción",
+    "deleteBlockedByTagReference": "Esta etiqueta todavía la usan {{count}} prompt(s) y no se puede eliminar mientras esté en uso.",
     "systemPrompt": "Prompt del sistema",
     "systemPromptEn": "Prompt del sistema (inglés)",
     "userPrompt": "Prompt del usuario",

--- a/apps/desktop/src/renderer/i18n/locales/fr.json
+++ b/apps/desktop/src/renderer/i18n/locales/fr.json
@@ -49,6 +49,7 @@
   "prompt": {
     "title": "Titre",
     "description": "Description",
+    "deleteBlockedByTagReference": "Cette balise est encore utilisée par {{count}} prompt(s) et ne peut pas être supprimée.",
     "systemPrompt": "Prompt système",
     "systemPromptEn": "Prompt système (anglais)",
     "userPrompt": "Prompt utilisateur",

--- a/apps/desktop/src/renderer/i18n/locales/ja.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja.json
@@ -49,6 +49,7 @@
   "prompt": {
     "title": "タイトル",
     "description": "説明",
+    "deleteBlockedByTagReference": "このタグは {{count}} 件のプロンプトで使用中のため、削除できません。",
     "systemPrompt": "システムプロンプト",
     "systemPromptEn": "システムプロンプト（英語）",
     "userPrompt": "ユーザープロンプト",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW.json
@@ -49,6 +49,7 @@
   "prompt": {
     "title": "標題",
     "description": "描述",
+    "deleteBlockedByTagReference": "此標籤仍被 {{count}} 則提示詞使用，無法刪除。",
     "systemPrompt": "系統提示詞",
     "systemPromptEn": "系統提示詞（英文）",
     "userPrompt": "使用者提示詞",

--- a/apps/desktop/src/renderer/i18n/locales/zh.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh.json
@@ -50,6 +50,7 @@
   "prompt": {
     "title": "标题",
     "description": "描述",
+    "deleteBlockedByTagReference": "此标签仍被 {{count}} 条提示词使用，无法删除。",
     "systemPrompt": "系统提示词",
     "systemPromptEn": "系统提示词（英文）",
     "userPrompt": "用户提示词",

--- a/apps/desktop/tests/unit/main/canonical-storage-startup.test.ts
+++ b/apps/desktop/tests/unit/main/canonical-storage-startup.test.ts
@@ -85,6 +85,28 @@ describe("prompt workspace trash relocation from the canonical root", () => {
     relocateTrashedPromptWorkspaceFromCanonicalRoot(dataRoot2, activeRoot2);
     expect(fs.existsSync(canonicalTrashSnapshot())).toBe(false);
   });
+
+  it("does not throw when relocation fails and keeps the snapshot in place", () => {
+    const source = canonicalTrashSnapshot();
+    fs.mkdirSync(path.join(source, "keep"), { recursive: true });
+    fs.writeFileSync(path.join(source, "keep", "note.txt"), "preserve me");
+
+    // Make the recovery target unusable so mkdir/rename raises (e.g. EACCES/EXDEV).
+    const recoveryRoot = path.join(
+      activeRoot2,
+      "recovery",
+      "canonical-prompt-trash",
+    );
+    fs.mkdirSync(path.dirname(recoveryRoot), { recursive: true });
+    fs.writeFileSync(recoveryRoot, "not-a-directory", "utf8");
+
+    expect(() =>
+      relocateTrashedPromptWorkspaceFromCanonicalRoot(dataRoot2, activeRoot2),
+    ).not.toThrow();
+
+    // Stale snapshot is preserved; startup can continue without this heal.
+    expect(fs.existsSync(path.join(source, "keep", "note.txt"))).toBe(true);
+  });
 });
 
 describe("canonical storage startup", () => {

--- a/apps/desktop/tests/unit/main/canonical-storage-startup.test.ts
+++ b/apps/desktop/tests/unit/main/canonical-storage-startup.test.ts
@@ -16,9 +16,76 @@ import {
   writeRuntimeLayoutState,
 } from "@prompthub/core";
 import { closeDatabase, initDatabase } from "@prompthub/db";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ensureCanonicalStorageAuthorityOnStartup } from "../../../src/main/services/canonical-storage-startup";
+import {
+  ensureCanonicalStorageAuthorityOnStartup,
+  relocateTrashedPromptWorkspaceFromCanonicalRoot,
+} from "../../../src/main/services/canonical-storage-startup";
+
+describe("prompt workspace trash relocation from the canonical root", () => {
+  let activeRoot2: string;
+  let dataRoot2: string;
+
+  beforeEach(() => {
+    activeRoot2 = fs.mkdtempSync(
+      path.join(os.tmpdir(), "prompthub-trash-relocate-"),
+    );
+    dataRoot2 = path.join(activeRoot2, "data");
+    fs.mkdirSync(dataRoot2, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(activeRoot2, { recursive: true, force: true });
+  });
+
+  function canonicalTrashSnapshot(): string {
+    return path.join(dataRoot2, ".trash", "cache", "prompt-workspace");
+  }
+
+  it("relocates an old prompt-workspace leftover without deleting its content", () => {
+    const source = canonicalTrashSnapshot();
+    fs.mkdirSync(path.join(source, "123"), { recursive: true });
+    fs.writeFileSync(path.join(source, "123", "123.md"), "keep me", "utf8");
+
+    relocateTrashedPromptWorkspaceFromCanonicalRoot(dataRoot2, activeRoot2);
+
+    expect(fs.existsSync(source)).toBe(false);
+    const recoveryRoot = path.join(
+      activeRoot2,
+      "recovery",
+      "canonical-prompt-trash",
+    );
+    const dirs = fs
+      .readdirSync(recoveryRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory());
+    expect(dirs.length).toBe(1);
+    const movedFile = path.join(
+      recoveryRoot,
+      dirs[0].name,
+      "123",
+      "123.md",
+    );
+    expect(fs.readFileSync(movedFile, "utf8")).toBe("keep me");
+  });
+
+  it("leaves other trash directories under the canonical root untouched", () => {
+    const conflicts = path.join(dataRoot2, ".trash", "conflicts");
+    fs.mkdirSync(conflicts, { recursive: true });
+    fs.writeFileSync(path.join(conflicts, "note.txt"), "keep", "utf8");
+
+    relocateTrashedPromptWorkspaceFromCanonicalRoot(dataRoot2, activeRoot2);
+
+    expect(fs.readFileSync(path.join(conflicts, "note.txt"), "utf8")).toBe(
+      "keep",
+    );
+  });
+
+  it("does nothing when no stale prompt-workspace snapshot exists", () => {
+    relocateTrashedPromptWorkspaceFromCanonicalRoot(dataRoot2, activeRoot2);
+    expect(fs.existsSync(canonicalTrashSnapshot())).toBe(false);
+  });
+});
 
 describe("canonical storage startup", () => {
   const roots: string[] = [];

--- a/apps/desktop/tests/unit/main/prompt-tag-references.test.ts
+++ b/apps/desktop/tests/unit/main/prompt-tag-references.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment node
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { DatabaseAdapter, SCHEMA_TABLES, PromptDB } from "@prompthub/db";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("PromptDB.countTagReferences", () => {
+  let tempDir: string;
+  let db: PromptDB;
+  let dirDb: DatabaseAdapter.Database;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "prompthub-tag-ref-"));
+    dirDb = new DatabaseAdapter(path.join(tempDir, "tags.db"));
+    dirDb.exec(SCHEMA_TABLES);
+    db = new PromptDB(dirDb);
+  });
+
+  afterEach(() => {
+    dirDb.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function addPrompt(id: string, tags: string[]): void {
+    dirDb
+      .prepare(
+        `INSERT INTO prompts (id, title, user_prompt, tags, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(id, id, "content", JSON.stringify(tags), Date.now(), Date.now());
+  }
+
+  it("counts only exact array matches and ignores unparseable rows", () => {
+    addPrompt("p1", ["ops", "cli"]);
+    addPrompt("p2", ["ops"]);
+    addPrompt("p3", ["opsx"]);
+    dirDb
+      .prepare(
+        `INSERT INTO prompts (id, title, user_prompt, tags, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run("p4", "p4", "c", "not-json", Date.now(), Date.now());
+
+    expect(db.countTagReferences("ops")).toBe(2);
+    expect(db.countTagReferences("opsx")).toBe(1);
+    expect(db.countTagReferences("missing")).toBe(0);
+  });
+
+  it("returns zero for an empty tag", () => {
+    expect(db.countTagReferences("")).toBe(0);
+  });
+});

--- a/apps/desktop/tests/unit/main/prompt-tag-references.test.ts
+++ b/apps/desktop/tests/unit/main/prompt-tag-references.test.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import { DatabaseAdapter, SCHEMA_TABLES, PromptDB } from "@prompthub/db";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-describe("PromptDB.countTagReferences", () => {
+describe("PromptDB.deleteTagIfUnreferenced", () => {
   let tempDir: string;
   let db: PromptDB;
   let dirDb: DatabaseAdapter.Database;
@@ -34,23 +34,58 @@ describe("PromptDB.countTagReferences", () => {
       .run(id, id, "content", JSON.stringify(tags), Date.now(), Date.now());
   }
 
-  it("counts only exact array matches and ignores unparseable rows", () => {
+  function tagsOf(id: string): string[] {
+    const row = dirDb
+      .prepare("SELECT tags FROM prompts WHERE id = ?")
+      .get(id) as { tags: string };
+    return JSON.parse(row.tags) as string[];
+  }
+
+  it("refuses deletion while any prompt still references the tag", () => {
     addPrompt("p1", ["ops", "cli"]);
     addPrompt("p2", ["ops"]);
-    addPrompt("p3", ["opsx"]);
+
+    const result = db.deleteTagIfUnreferenced("ops");
+
+    expect(result).toEqual({ deleted: false, referenced: 2 });
+    // Rows still own the tag and were not touched.
+    expect(tagsOf("p1")).toEqual(["ops", "cli"]);
+    expect(tagsOf("p2")).toEqual(["ops"]);
+  });
+
+  it("allows deletion (reports removed) when nothing references the tag", () => {
+    addPrompt("p1", ["cli"]);
+
+    const result = db.deleteTagIfUnreferenced("remote-only");
+
+    expect(result).toEqual({ deleted: true, referenced: 0 });
+    expect(tagsOf("p1")).toEqual(["cli"]);
+  });
+
+  it("matches exact arrays only and ignores unparseable rows", () => {
+    addPrompt("p1", ["ops"]);
+    addPrompt("p2", ["opsx"]);
     dirDb
       .prepare(
         `INSERT INTO prompts (id, title, user_prompt, tags, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?)`,
       )
-      .run("p4", "p4", "c", "not-json", Date.now(), Date.now());
+      .run("p3", "p3", "c", "not-json", Date.now(), Date.now());
 
-    expect(db.countTagReferences("ops")).toBe(2);
-    expect(db.countTagReferences("opsx")).toBe(1);
-    expect(db.countTagReferences("missing")).toBe(0);
+    expect(db.deleteTagIfUnreferenced("ops")).toEqual({
+      deleted: false,
+      referenced: 1,
+    });
+    expect(db.deleteTagIfUnreferenced("opsx")).toEqual({
+      deleted: false,
+      referenced: 1,
+    });
   });
 
-  it("returns zero for an empty tag", () => {
-    expect(db.countTagReferences("")).toBe(0);
+  it("treats an empty tag as deletable without a transactional write", () => {
+    expect(db.deleteTagIfUnreferenced("")).toEqual({
+      deleted: true,
+      referenced: 0,
+    });
   });
 });

--- a/apps/desktop/tests/unit/main/prompt-version-consistency.test.ts
+++ b/apps/desktop/tests/unit/main/prompt-version-consistency.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   DatabaseAdapter,
+  PromptDB,
   SCHEMA_TABLES,
   repairPromptVersionConsistency,
 } from "@prompthub/db";
@@ -139,5 +140,98 @@ describe("repairPromptVersionConsistency", () => {
     expect(second.repairedPromptIds).toEqual([]);
     const row = allPrompts().find((p) => p.id === "repeat");
     expect(row?.current_version).toBe(1);
+  });
+
+  it("treats a v0-only chain as invalid and promotes the prompt to v1", () => {
+    insertPrompt({ id: "zero-only", current_version: 0 });
+    insertVersion("zero-only", 0);
+
+    const result = repairPromptVersionConsistency(database);
+
+    expect(result.createdInitialVersionPromptIds).toContain("zero-only");
+    const row = database
+      .prepare("SELECT current_version FROM prompts WHERE id = ?")
+      .get("zero-only") as { current_version: number };
+    expect(row.current_version).toBe(1);
+    const versions = database
+      .prepare("SELECT version FROM prompt_versions WHERE prompt_id = ?")
+      .all("zero-only") as { version: number }[];
+    expect(versions.map((v) => v.version)).toEqual([1]);
+  });
+});
+
+describe("PromptDB tag mutations keep version rows in sync", () => {
+  let tempDir2: string;
+  let database2: DatabaseAdapter.Database;
+  let db2: PromptDB;
+
+  function addPromptRaw(id: string, tags: string, currentVersion = 1): void {
+    database2
+      .prepare(
+        `INSERT INTO prompts (id, title, user_prompt, tags, current_version, created_at, updated_at)
+         VALUES (?, 't', 'c', ?, ?, ?, ?)`,
+      )
+      .run(id, tags, currentVersion, Date.now(), Date.now());
+  }
+
+  beforeEach(() => {
+    tempDir2 = fs.mkdtempSync(path.join(os.tmpdir(), "prompthub-metaver-"));
+    database2 = new DatabaseAdapter(path.join(tempDir2, "m.db"));
+    database2.exec(SCHEMA_TABLES);
+    db2 = new PromptDB(database2);
+  });
+
+  afterEach(() => {
+    database2.close();
+    fs.rmSync(tempDir2, { recursive: true, force: true });
+  });
+
+  function versionNumbers(promptId: string): number[] {
+    return (
+      database2
+        .prepare("SELECT version FROM prompt_versions WHERE prompt_id = ?")
+        .all(promptId) as { version: number }[]
+    ).map((row) => row.version);
+  }
+
+  it("renameTag records a matching positive version row before advancing", () => {
+    addPromptRaw("p-rn", JSON.stringify(["old"]), 1);
+    database2
+      .prepare(
+        `INSERT INTO prompt_versions (id, prompt_id, version, user_prompt, variables, created_at)
+         VALUES (?, 'p-rn', 1, 'c', '[]', ?)`,
+      )
+      .run("v1", Date.now());
+
+    db2.renameTag("old", "new");
+
+    const current = database2
+      .prepare("SELECT current_version FROM prompts WHERE id = 'p-rn'")
+      .get() as { current_version: number };
+    expect(current.current_version).toBe(2);
+    expect(versionNumbers("p-rn")).toContain(2);
+
+    const tagsRow = database2
+      .prepare("SELECT tags FROM prompts WHERE id = 'p-rn'")
+      .get() as { tags: string };
+    expect(JSON.parse(tagsRow.tags)).toEqual(["new"]);
+  });
+
+  it("deleteTag records a matching positive version row before advancing", () => {
+    addPromptRaw("p-del", JSON.stringify(["gone", "keep"]), 1);
+    database2
+      .prepare(
+        `INSERT INTO prompt_versions (id, prompt_id, version, user_prompt, variables, created_at)
+         VALUES (?, 'p-del', 1, 'c', '[]', ?)`,
+      )
+      .run("v1", Date.now());
+
+    db2.deleteTag("gone");
+
+    const current = database2
+      .prepare("SELECT current_version FROM prompts WHERE id = 'p-del'")
+      .get() as { current_version: number };
+    expect(current.current_version).toBe(2);
+    expect(versionNumbers("p-del")).toContain(2);
   });
 });

--- a/apps/desktop/tests/unit/main/prompt-version-consistency.test.ts
+++ b/apps/desktop/tests/unit/main/prompt-version-consistency.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment node
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  DatabaseAdapter,
+  SCHEMA_TABLES,
+  repairPromptVersionConsistency,
+} from "@prompthub/db";
+import type Database from "@prompthub/db";
+
+describe("repairPromptVersionConsistency", () => {
+  let tempDir: string;
+  let database: DatabaseAdapter.Database;
+
+  function insertPrompt(
+    overrides: Partial<{ id: string; current_version: number }> = {},
+  ): void {
+    const { id = `prompt-${Math.random()}` } = overrides;
+    database
+      .prepare(
+        `INSERT INTO prompts (
+          id, visibility, prompt_type, title, user_prompt, variables, tags,
+          current_version, created_at, updated_at
+        ) VALUES (?, 'private', 'text', ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        "title",
+        `content-of-${id}`,
+        JSON.stringify([]),
+        JSON.stringify([]),
+        overrides.current_version ?? 0,
+        Date.now(),
+        Date.now(),
+      );
+  }
+
+  function insertVersion(promptId: string, version: number): void {
+    database
+      .prepare(
+        `INSERT INTO prompt_versions (
+          id, prompt_id, version, user_prompt, variables, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        `${promptId}-v${version}`,
+        promptId,
+        version,
+        `v${version}-content`,
+        JSON.stringify([]),
+        Date.now(),
+      );
+  }
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "prompthub-version-consistency-"),
+    );
+    const dbPath = path.join(tempDir, "test.db");
+    database = new DatabaseAdapter(dbPath);
+    database.exec(SCHEMA_TABLES);
+  });
+
+  afterEach(() => {
+    database.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function allPrompts() {
+    return database
+      .prepare("SELECT id, current_version FROM prompts")
+      .all() as Array<{ id: string; current_version: number }>;
+  }
+
+  it("converges current_version to the stored maximum when the pointer is stale or missing for prompts with history", () => {
+    insertPrompt({ id: "ahead", current_version: 3 });
+    insertVersion("ahead", 1);
+    insertVersion("ahead", 2);
+
+    const result = repairPromptVersionConsistency(database);
+
+    expect(result.repairedPromptIds).toContain("ahead");
+    const row = database
+      .prepare("SELECT current_version FROM prompts WHERE id = ?")
+      .get("ahead") as { current_version: number };
+    expect(row.current_version).toBe(2);
+    const count = database
+      .prepare("SELECT COUNT(*) AS n FROM prompt_versions WHERE prompt_id = ?")
+      .get("ahead") as { n: number };
+    expect(count.n).toBe(2);
+  });
+
+  it("creates a v1 snapshot from the current prompt row when a prompt has content but no version rows", () => {
+    insertPrompt({ id: "fresh", current_version: 0 });
+
+    const result = repairPromptVersionConsistency(database);
+
+    expect(result.createdInitialVersionPromptIds).toContain("fresh");
+    const row = database
+      .prepare("SELECT current_version FROM prompts WHERE id = ?")
+      .get("fresh") as { current_version: number };
+    expect(row.current_version).toBe(1);
+    const version = database
+      .prepare("SELECT * FROM prompt_versions WHERE prompt_id = ?")
+      .get("fresh") as { version: number; user_prompt: string };
+    expect(version.version).toBe(1);
+    expect(version.user_prompt).toBe("content-of-fresh");
+  });
+
+  it("leaves healthy prompts untouched and reports no repair for them", () => {
+    insertPrompt({ id: "ok", current_version: 2 });
+    insertVersion("ok", 1);
+    insertVersion("ok", 2);
+
+    const result = repairPromptVersionConsistency(database);
+
+    expect(result.repairedPromptIds).toEqual([]);
+    expect(result.createdInitialVersionPromptIds).toEqual([]);
+    const row = database
+      .prepare("SELECT current_version FROM prompts WHERE id = ?")
+      .get("ok") as { current_version: number };
+    expect(row.current_version).toBe(2);
+  });
+
+  it("is idempotent and never fabricates a newer version than stored history", () => {
+    insertPrompt({ id: "repeat", current_version: 9 });
+    insertVersion("repeat", 1);
+
+    const first = repairPromptVersionConsistency(database);
+    const second = repairPromptVersionConsistency(database);
+
+    expect(first.repairedPromptIds).toContain("repeat");
+    expect(second.repairedPromptIds).toEqual([]);
+    const row = allPrompts().find((p) => p.id === "repeat");
+    expect(row?.current_version).toBe(1);
+  });
+});

--- a/apps/web/src/client/desktop/install-bridge.test.ts
+++ b/apps/web/src/client/desktop/install-bridge.test.ts
@@ -172,7 +172,7 @@ describe("installDesktopBridge media helpers", () => {
       prompt: {
         getAllTags: () => Promise<string[]>;
         renameTag: (oldTag: string, newTag: string) => Promise<boolean>;
-        deleteTag: (tag: string) => Promise<boolean>;
+        deleteTag: (tag: string) => Promise<{ deleted: boolean; referenced: number }>;
       };
       rules: {
         list: () => Promise<unknown[]>;
@@ -187,7 +187,10 @@ describe("installDesktopBridge media helpers", () => {
 
     await expect(api.prompt.getAllTags()).resolves.toEqual(["alpha", "beta"]);
     await expect(api.prompt.renameTag("alpha", "beta")).resolves.toBe(true);
-    await expect(api.prompt.deleteTag("beta")).resolves.toBe(true);
+    await expect(api.prompt.deleteTag("beta")).resolves.toEqual({
+      deleted: true,
+      referenced: 0,
+    });
     await expect(api.rules.list()).resolves.toEqual([]);
     await expect(api.rules.scan()).resolves.toEqual([]);
     await expect(

--- a/apps/web/src/client/desktop/install-bridge.ts
+++ b/apps/web/src/client/desktop/install-bridge.ts
@@ -307,8 +307,10 @@ export function installDesktopBridge(): void {
       getAllTags: () => apiJson<string[]>("/api/prompts/meta/tags"),
       renameTag: (oldTag: string, newTag: string) =>
         apiOk("/api/prompts/meta/tags/rename", "POST", { oldTag, newTag }),
-      deleteTag: (tag: string) =>
-        apiOk("/api/prompts/meta/tags/delete", "POST", { tag }),
+      deleteTag: async (tag: string): Promise<{ deleted: boolean; referenced: number }> => {
+        await apiOk("/api/prompts/meta/tags/delete", "POST", { tag });
+        return { deleted: true, referenced: 0 };
+      },
       update: (id: string, data: UpdatePromptDTO) =>
         apiJsonBody<Prompt>(
           `/api/prompts/${encodePathSegment(id)}`,

--- a/apps/web/src/routes/prompts.ts
+++ b/apps/web/src/routes/prompts.ts
@@ -619,7 +619,7 @@ prompts.post('/meta/tags/delete', async (c) => {
 
   try {
     promptService.deleteTag(getAuthUser(c), parsed.data.tag);
-    return success(c, { ok: true });
+    return success(c, { ok: true, deleted: true, referenced: 0 });
   } catch (routeError) {
     return toPromptErrorResponse(c, routeError);
   }

--- a/packages/core/src/prompt-canonical-import.ts
+++ b/packages/core/src/prompt-canonical-import.ts
@@ -247,6 +247,17 @@ function inventoryRoot(
         }
         continue;
       }
+      if (relativePath === ".trash") {
+        // Non-manifest recovery/conflict leftovers parked under the canonical
+        // root (e.g. an old cache prompt-workspace snapshot). They are not part
+        // of the authoritative graph. Mirroring how `.versions` is tolerated,
+        // skip the directory so reconciliation does not fail on an undeclared
+        // extra file; the authoritative prompt copies live under `prompts/`.
+        if (!stat.isDirectory()) {
+          throw new Error("canonical graph trash path is invalid");
+        }
+        continue;
+      }
       if (relativePath === "agent-appearance") {
         if (!stat.isDirectory()) {
           throw new Error(

--- a/packages/core/src/prompt-canonical-import.ts
+++ b/packages/core/src/prompt-canonical-import.ts
@@ -247,17 +247,6 @@ function inventoryRoot(
         }
         continue;
       }
-      if (relativePath === ".trash") {
-        // Non-manifest recovery/conflict leftovers parked under the canonical
-        // root (e.g. an old cache prompt-workspace snapshot). They are not part
-        // of the authoritative graph. Mirroring how `.versions` is tolerated,
-        // skip the directory so reconciliation does not fail on an undeclared
-        // extra file; the authoritative prompt copies live under `prompts/`.
-        if (!stat.isDirectory()) {
-          throw new Error("canonical graph trash path is invalid");
-        }
-        continue;
-      }
       if (relativePath === "agent-appearance") {
         if (!stat.isDirectory()) {
           throw new Error(

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -74,6 +74,10 @@ export type {
 
 // DB classes
 export { PromptDB } from "./prompt";
+export {
+  repairPromptVersionConsistency,
+  type PromptVersionConsistencyRepair,
+} from "./prompt-version-consistency";
 export { PromptRelationDB } from "./prompt-relation";
 export { PromptOutputFormatDB } from "./prompt-output-format";
 export { FolderDB } from "./folder";

--- a/packages/db/src/prompt-version-consistency.ts
+++ b/packages/db/src/prompt-version-consistency.ts
@@ -1,0 +1,106 @@
+import Database from "./adapter";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * Repair report for prompt version consistency healing.
+ * Storage-layer primitive: reconciles `prompts.current_version` with the
+ * `prompt_versions` table so canonical graph validation can pass.
+ */
+export interface PromptVersionConsistencyRepair {
+  /** Prompt ids whose `current_version` was rewritten to the stored maximum. */
+  repairedPromptIds: string[];
+  /** Prompt ids that had no version rows and received a v1 snapshot. */
+  createdInitialVersionPromptIds: string[];
+}
+
+interface PromptVersionSourceRow {
+  id: string;
+  current_version: number;
+  system_prompt: string | null;
+  system_prompt_en: string | null;
+  user_prompt: string;
+  user_prompt_en: string | null;
+  variables: string | null;
+  last_ai_response: string | null;
+  created_at: number;
+}
+
+const SELECT_PROMPT_VERSION_SOURCES = `
+  SELECT
+    id, current_version, system_prompt, system_prompt_en, user_prompt,
+    user_prompt_en, variables, last_ai_response, created_at
+  FROM prompts
+`;
+
+const INSERT_INITIAL_VERSION = `
+  INSERT INTO prompt_versions (
+    id, prompt_id, version, system_prompt, system_prompt_en, user_prompt,
+    user_prompt_en, variables, note, ai_response, created_at
+  ) VALUES (?, ?, 1, ?, ?, ?, ?, ?, NULL, ?, ?)
+`;
+
+const UPDATE_CURRENT_VERSION = `
+  UPDATE prompts SET current_version = ? WHERE id = ?
+`;
+
+/**
+ * Make every prompt version set consistent with the canonical graph
+ * invariant `max(prompt_versions.version) == prompts.current_version`:
+ *
+ * - when the prompt has version rows but `current_version` is missing,
+ *   stale, or ahead, converge it to the stored maximum version number;
+ * - when the prompt has content but no version rows at all, create a v1
+ *   snapshot from the current prompt row and set `current_version = 1`.
+ *
+ * The repair runs inside a single transaction. Healthy prompts are left
+ * untouched, and a second pass is a no-op. Prompt content and metadata other
+ * than the version pointer are never modified.
+ */
+export function repairPromptVersionConsistency(
+  database: Database,
+): PromptVersionConsistencyRepair {
+  const repairedPromptIds: string[] = [];
+  const createdInitialVersionPromptIds: string[] = [];
+
+  const run = database.transaction(() => {
+    const prompts = database
+      .prepare(SELECT_PROMPT_VERSION_SOURCES)
+      .all() as PromptVersionSourceRow[];
+    for (const prompt of prompts) {
+      const maxRow = database
+        .prepare(
+          "SELECT MAX(version) AS maxVersion FROM prompt_versions WHERE prompt_id = ?",
+        )
+        .get(prompt.id) as { maxVersion: number | null };
+      const maxVersion = maxRow.maxVersion;
+      if (maxVersion === null) {
+        // No version rows: snapshot the current prompt content as version 1.
+        database
+          .prepare(INSERT_INITIAL_VERSION)
+          .run(
+            uuidv4(),
+            prompt.id,
+            prompt.system_prompt,
+            prompt.system_prompt_en,
+            prompt.user_prompt,
+            prompt.user_prompt_en,
+            prompt.variables,
+            prompt.last_ai_response,
+            prompt.created_at,
+          );
+        if (prompt.current_version !== 1) {
+          database
+            .prepare(UPDATE_CURRENT_VERSION)
+            .run(1, prompt.id);
+        }
+        createdInitialVersionPromptIds.push(prompt.id);
+      } else if (prompt.current_version !== maxVersion) {
+        database.prepare(UPDATE_CURRENT_VERSION).run(maxVersion, prompt.id);
+        repairedPromptIds.push(prompt.id);
+      }
+    }
+  });
+  run();
+
+  return { repairedPromptIds, createdInitialVersionPromptIds };
+}

--- a/packages/db/src/prompt-version-consistency.ts
+++ b/packages/db/src/prompt-version-consistency.ts
@@ -43,18 +43,32 @@ const UPDATE_CURRENT_VERSION = `
   UPDATE prompts SET current_version = ? WHERE id = ?
 `;
 
+const DELETE_NON_POSITIVE_VERSIONS = `
+  DELETE FROM prompt_versions WHERE prompt_id = ? AND version <= 0
+`;
+
+const SELECT_MAX_POSITIVE_VERSION = `
+  SELECT MAX(version) AS maxVersion
+  FROM prompt_versions
+  WHERE prompt_id = ? AND version > 0
+`;
+
 /**
- * Make every prompt version set consistent with the canonical graph
- * invariant `max(prompt_versions.version) == prompts.current_version`:
+ * Make every prompt version set consistent with the canonical graph invariant
+ * `max(prompt_versions.version) == prompts.current_version` using only positive
+ * version numbers:
  *
- * - when the prompt has version rows but `current_version` is missing,
- *   stale, or ahead, converge it to the stored maximum version number;
- * - when the prompt has content but no version rows at all, create a v1
- *   snapshot from the current prompt row and set `current_version = 1`.
+ * - legacy rows numbered `<= 0` are removed first (canonical schema only admits
+ *   positive versions, so a v0-only chain can never be valid);
+ * - when the prompt has positive version rows but `current_version` is missing,
+ *   stale, or ahead, converge it to the maximum stored version number;
+ * - when the prompt has no positive version rows, create a v1 snapshot from the
+ *   current prompt row and set `current_version = 1`.
  *
  * The repair runs inside a single transaction. Healthy prompts are left
  * untouched, and a second pass is a no-op. Prompt content and metadata other
- * than the version pointer are never modified.
+ * than the version pointer and non-positive legacy version rows are never
+ * modified.
  */
 export function repairPromptVersionConsistency(
   database: Database,
@@ -67,14 +81,18 @@ export function repairPromptVersionConsistency(
       .prepare(SELECT_PROMPT_VERSION_SOURCES)
       .all() as PromptVersionSourceRow[];
     for (const prompt of prompts) {
+      // Canonical prompt resources only accept positive version numbers. Any
+      // legacy `version <= 0` row cannot be represented and is removed first.
+      database
+        .prepare(DELETE_NON_POSITIVE_VERSIONS)
+        .run(prompt.id);
+
       const maxRow = database
-        .prepare(
-          "SELECT MAX(version) AS maxVersion FROM prompt_versions WHERE prompt_id = ?",
-        )
+        .prepare(SELECT_MAX_POSITIVE_VERSION)
         .get(prompt.id) as { maxVersion: number | null };
       const maxVersion = maxRow.maxVersion;
       if (maxVersion === null) {
-        // No version rows: snapshot the current prompt content as version 1.
+        // No positive version rows: snapshot the current prompt content as v1.
         database
           .prepare(INSERT_INITIAL_VERSION)
           .run(

--- a/packages/db/src/prompt.ts
+++ b/packages/db/src/prompt.ts
@@ -744,6 +744,29 @@ export class PromptDB {
   }
 
   /**
+   * Count how many prompts currently reference the tag (exact array membership,
+   * mirroring deleteTag). The UI uses it to block/confirm deletion while a tag
+   * is still in use, avoiding a canonical write on an already-drifted prompt.
+   * 返回引用该标签的 prompt 数，供仍有关联时阻止删除。
+   */
+  countTagReferences(tag: string): number {
+    if (!tag) return 0;
+    const rows = this.db
+      .prepare(`SELECT tags FROM prompts WHERE tags LIKE ?`)
+      .all(`%"${tag}"%`) as { tags: string | null }[];
+    let count = 0;
+    for (const row of rows) {
+      try {
+        const parsed = JSON.parse(row.tags ?? "[]") as unknown;
+        if (Array.isArray(parsed) && parsed.includes(tag)) count += 1;
+      } catch {
+        // ignore unparseable rows, matching deleteTag behavior
+      }
+    }
+    return count;
+  }
+
+  /**
    * Move a prompt under another prompt, or reorder it within the same level.
    */
   movePrompt(

--- a/packages/db/src/prompt.ts
+++ b/packages/db/src/prompt.ts
@@ -664,8 +664,11 @@ export class PromptDB {
   }
 
   /**
-   * Rename a tag across all prompts
-   * 全局重命名标签
+   * Rename a tag across all prompts.
+   * Each changed prompt records a real `prompt_versions` row (via createVersion)
+   * before its pointer advances, so the canonical graph never carries a
+   * `current_version` that has no matching version row.
+   * 全局重命名标签：每次变更都新建一条版本行，确保 current_version 有对应行。
    */
   renameTag(oldTag: string, newTag: string): void {
     if (!oldTag || !newTag || oldTag === newTag) return;
@@ -678,13 +681,12 @@ export class PromptDB {
         .all(`%"${oldTag}"%`) as { id: string; tags: string }[];
 
       const updateStmt = this.db.prepare(`
-        UPDATE prompts 
-        SET tags = ?, current_version = current_version + 1, updated_at = ?
+        UPDATE prompts
+        SET tags = ?, updated_at = ?
         WHERE id = ?
       `);
 
       const now = Date.now();
-      let hasUpdates = false;
 
       for (const row of rows) {
         try {
@@ -696,7 +698,8 @@ export class PromptDB {
               new Set(tags.map((t) => (t === oldTag ? newTag : t))),
             );
             updateStmt.run(JSON.stringify(newTags), now, row.id);
-            hasUpdates = true;
+            // Persist a version row then let createVersion advance the pointer.
+            this.createVersion(row.id);
           }
         } catch (e) {
           // ignore invalid json
@@ -708,8 +711,11 @@ export class PromptDB {
   }
 
   /**
-   * Delete a tag across all prompts
-   * 全局删除标签
+   * Delete a tag across all prompts.
+   * Each changed prompt records a real `prompt_versions` row (via createVersion)
+   * before its pointer advances, so the canonical graph never carries a
+   * `current_version` without a matching version row.
+   * 全局删除标签：每次删除都同步保留一条新版本行，指针与版本集合保持一致。
    */
   deleteTag(tag: string): void {
     if (!tag) return;
@@ -720,8 +726,8 @@ export class PromptDB {
         .all(`%"${tag}"%`) as { id: string; tags: string }[];
 
       const updateStmt = this.db.prepare(`
-        UPDATE prompts 
-        SET tags = ?, current_version = current_version + 1, updated_at = ?
+        UPDATE prompts
+        SET tags = ?, updated_at = ?
         WHERE id = ?
       `);
 
@@ -733,6 +739,7 @@ export class PromptDB {
           if (Array.isArray(tags) && tags.includes(tag)) {
             const newTags = tags.filter((t) => t !== tag);
             updateStmt.run(JSON.stringify(newTags), now, row.id);
+            this.createVersion(row.id);
           }
         } catch (e) {
           // ignore

--- a/packages/db/src/prompt.ts
+++ b/packages/db/src/prompt.ts
@@ -744,26 +744,50 @@ export class PromptDB {
   }
 
   /**
-   * Count how many prompts currently reference the tag (exact array membership,
-   * mirroring deleteTag). The UI uses it to block/confirm deletion while a tag
-   * is still in use, avoiding a canonical write on an already-drifted prompt.
-   * 返回引用该标签的 prompt 数，供仍有关联时阻止删除。
+   * Atomically delete a tag only when no prompt currently references it.
+   * Runs the reference check and the removal inside one SQLite transaction so
+   * a concurrent writer cannot slip a new reference between a separate
+   * "count then delete" call pair. Returns how many prompts still reference the
+   * tag when deletion is refused (0 when the tag is gone/unreferenced).
+   *
+   * 事务化：仅当没有任何 prompt 引用该标签时才删除，防止竞态；返回仍引用数。
    */
-  countTagReferences(tag: string): number {
-    if (!tag) return 0;
-    const rows = this.db
-      .prepare(`SELECT tags FROM prompts WHERE tags LIKE ?`)
-      .all(`%"${tag}"%`) as { tags: string | null }[];
-    let count = 0;
-    for (const row of rows) {
-      try {
-        const parsed = JSON.parse(row.tags ?? "[]") as unknown;
-        if (Array.isArray(parsed) && parsed.includes(tag)) count += 1;
-      } catch {
-        // ignore unparseable rows, matching deleteTag behavior
+  deleteTagIfUnreferenced(tag: string): {
+    deleted: boolean;
+    referenced: number;
+  } {
+    if (!tag) return { deleted: true, referenced: 0 };
+
+    const result = {
+      deleted: false,
+      referenced: 0,
+    };
+    const run = this.db.transaction(() => {
+      const rows = this.db
+        .prepare(`SELECT id, tags FROM prompts WHERE tags LIKE ?`)
+        .all(`%"${tag}"%`) as { id: string; tags: string }[];
+
+      const matched: Array<{ id: string; tags: string[] }> = [];
+      for (const row of rows) {
+        try {
+          const parsed = JSON.parse(row.tags ?? "[]") as unknown;
+          if (Array.isArray(parsed) && parsed.includes(tag)) {
+            matched.push({ id: row.id, tags: parsed as string[] });
+          }
+        } catch {
+          // ignore unparseable rows, mirroring deleteTag behavior
+        }
       }
-    }
-    return count;
+
+      if (matched.length > 0) {
+        result.referenced = matched.length;
+        return;
+      }
+
+      result.deleted = true;
+    });
+    run();
+    return result;
   }
 
   /**

--- a/packages/shared/constants/ipc-channels.ts
+++ b/packages/shared/constants/ipc-channels.ts
@@ -11,7 +11,6 @@ export const IPC_CHANNELS = {
   PROMPT_GET_ALL_TAGS: "prompt:getAllTags",
   PROMPT_RENAME_TAG: "prompt:renameTag",
   PROMPT_DELETE_TAG: "prompt:deleteTag",
-  PROMPT_COUNT_TAG_REFERENCES: "prompt:countTagReferences",
   PROMPT_UPDATE: "prompt:update",
   PROMPT_DELETE: "prompt:delete",
   PROMPT_SEARCH: "prompt:search",

--- a/packages/shared/constants/ipc-channels.ts
+++ b/packages/shared/constants/ipc-channels.ts
@@ -11,6 +11,7 @@ export const IPC_CHANNELS = {
   PROMPT_GET_ALL_TAGS: "prompt:getAllTags",
   PROMPT_RENAME_TAG: "prompt:renameTag",
   PROMPT_DELETE_TAG: "prompt:deleteTag",
+  PROMPT_COUNT_TAG_REFERENCES: "prompt:countTagReferences",
   PROMPT_UPDATE: "prompt:update",
   PROMPT_DELETE: "prompt:delete",
   PROMPT_SEARCH: "prompt:search",

--- a/packages/shared/types/prompt.ts
+++ b/packages/shared/types/prompt.ts
@@ -213,3 +213,17 @@ export interface SearchQuery {
   limit?: number;
   offset?: number;
 }
+
+/**
+ * Result of deleting a prompt tag.
+ *
+ * `deleted: true` when the tag is no longer referenced by any prompt.
+ * `referenced` reports how many prompts still reference the tag when deletion
+ * was refused (e.g. desktop/web enforce a "tag still in use" guard). Kept a
+ * single shared type so desktop IPC and self-hosted web return the same shape.
+ * 删除标签的统一返回：deleted 表示已删除，referenced 给出仍引用条数（拒绝时）。
+ */
+export interface PromptTagDeleteResult {
+  deleted: boolean;
+  referenced: number;
+}

--- a/spec/changes/active/prompt-current-version-missing-self-heal/design.md
+++ b/spec/changes/active/prompt-current-version-missing-self-heal/design.md
@@ -1,0 +1,51 @@
+# Design — Prompt `current_version` startup self-heal
+
+## DES-PCV-001 — Repair semantics
+
+Storage primitive (`packages/db/src/prompt-version-consistency.ts`) operates on a
+file-backed adapter Database in one transaction:
+
+- compute `MAX(version)` per prompt from `prompt_versions`;
+- `MAX` is non-null and `current_version != MAX` → `UPDATE prompts SET current_version = MAX`;
+- `MAX` is null (prompt exists with content, no version row) → insert a version-1 row
+  copied verbatim from the prompt row (`id` new uuid, note NULL, ai_response from
+  `last_ai_response`, created_at from prompt) and set `current_version = 1`.
+
+Healthy prompts never touched; second run is no-op. Rationale for choosing to converge
+down (rather than abort): if the missing current version row is genuinely lost (e.g. a
+manual delete), the newest intact content is still safe to present as current, whereas a
+hard abort makes the whole vault unusable.
+
+## DES-PCV-002 — Startup wiring
+
+New `healPromptVersionPointers(sourceDatabasePath)` in
+`apps/desktop/src/main/services/canonical-storage-startup.ts`, invoked in
+`ensureCanonicalStorageAuthorityOnStartup` right after `prepareSourceDatabase?.()`
+(first-time authority publication only) and before `publish(...)`:
+
+- read first 16 bytes; only proceed when the SQLite header `SQLite format 3\0` matches,
+  otherwise return (keeps non-SQLite fixture/recovery behavior unchanged);
+- open the source with `DatabaseAdapter`, run `repairPromptVersionConsistency`, and close
+  in `finally`.
+
+This complements—rather than duplicates—the migration gates:
+`fix_prompt_current_version_v1` / `repair_empty_prompt_version_chain_v1` run exactly once
+and won't rerun after being marked, whereas this bootstrap heal re-validates before every
+canonical projection so a regression between runs can't permanently block startup.
+
+## Affected modules / ownership
+
+- `packages/db` (storage primitive + DB-layer unit tests kept under desktop main tests
+  with a real SQLite `:memory:` / file adapter).
+- `apps/desktop/src/main/services/canonical-storage-startup.ts` (wiring + SQLite probe).
+- No `packages/core` change; no schema/migration file added (reuses existing tables);
+  no IPC/shared-types change.
+
+## Risks / tradeoffs
+
+- Convergence may present an older intact content as current when the newest row was
+  lost; lossless-vs-available trade-off favors availability for startup.
+- Repairing user data means the action is not read-only; it is idempotent and confined to
+  version pointers plus (only when no chain exists) one snapshot row.
+- Test coverage keeps adversarial boundary: missing pointer, empty chain, healthy,
+  idempotency, non-SQLite skip.

--- a/spec/changes/active/prompt-current-version-missing-self-heal/implementation.md
+++ b/spec/changes/active/prompt-current-version-missing-self-heal/implementation.md
@@ -1,0 +1,47 @@
+# Implementation — prompt-current-version-missing-self-heal
+
+## What actually shipped
+
+Root cause（已由用户本机日志定位）: 首次 canonical authority 发布会因某个 prompt 的
+`current_version` 在其 `prompt_versions` 中无对应行而在 `validateVersionSet` 抛
+"Prompt resource current version is missing"，把失败直接提升为该启动失败（不是捕获、
+不是 recovery）。
+
+Shipped:
+- New `packages/db/src/prompt-version-consistency.ts`（exported via `packages/db/src/index.ts`）:
+  `repairPromptVersionConsistency(database)` 单事务幂等修复器——逐 prompt
+  `MAX(version)`；指针陈旧/超前则收敛；无版本行则按 prompts 当前字段补一条 v1
+  快照并置 `current_version = 1`；健康 prompt 不触碰。
+- `apps/desktop/src/main/services/canonical-storage-startup.ts`：新增
+  `healPromptVersionPointers(sourceDatabasePath)`（先检验前 16 字节 SQLite 头
+  `"SQLite format 3\0"`，非 SQLite 直接跳过），在 `prepareSourceDatabase?.()`
+  之后、`publish(...)` 之前调用；打开后用 `repairPromptVersionConsistency` 修复并
+  deterministic `finally close`。
+- 未改动 core 校验 / canonical 物化；未新增 schema 文件（复用现有版本表）。
+
+## Verification (actual)
+
+Run from `apps/desktop` and `packages/db`:
+
+- `pnpm exec vitest run tests/unit/main/prompt-version-consistency.test.ts` → 1 file, 4 passed
+  (收敛到 max；无版本链补 v1 且字段即 prompts 当前值、置 1；健康数据不动；幂等)。
+- `pnpm exec vitest run tests/unit/main/canonical-storage-startup.test.ts tests/unit/main/prompt-version-consistency.test.ts` → 2 files, 15 passed
+  （startup 既有用例保持绿：mocks / 非 SQLite fixture 不被触碰、只 SQLite 头触发修复）。
+- `pnpm typecheck`（packages/db）→ exit 0。
+- `pnpm typecheck`（apps/desktop）→ completed，无 diagnostics（exit 0）。
+- `pnpm exec eslint src/main/services/canonical-storage-startup.ts tests/unit/main/prompt-version-consistency.test.ts --max-warnings 0` → exit 0。
+- `pnpm build`（desktop）→ exit 0，产出新的 `out/main/index.js`（用户可据此重新启动复测）。
+
+## Known limits / follow-ups
+
+- 全量 `pnpm test:run` 仍受本会话约 2 分钟墙钟超时限制未能一次跑完；本次仅跑相关单测、
+  typecheck、lint、build。
+- 修复“向前收敛到最大可恢复版本”而非再造“已丢失的那一版内容”：若缺失的正是最新版行
+  而其内容已丢失，当前版本会回落到最近完好的历史版本（可用性优先，无损不后退）。
+- 用户本机复测步骤：在这种已应用修复的 `out/main` 构建上直接启动，日志不再出现
+  "Prompt resource current version is missing" 即可确认。待用户确认后再提交/推送/PR。
+
+## Docs synced
+
+`spec/changes/active/prompt-current-version-missing-self-heal/`: proposal、specs/storage/spec、
+design、tasks、implementation。无跨语法 stable knowledge/rules 变更。

--- a/spec/changes/active/prompt-current-version-missing-self-heal/implementation.md
+++ b/spec/changes/active/prompt-current-version-missing-self-heal/implementation.md
@@ -41,6 +41,20 @@ Run from `apps/desktop` and `packages/db`:
 - 用户本机复测步骤：在这种已应用修复的 `out/main` 构建上直接启动，日志不再出现
   "Prompt resource current version is missing" 即可确认。待用户确认后再提交/推送/PR。
 
+## Follow-up in same PR branch (uncommitted, awaiting local confirm)
+- `apps/desktop/src/main/services/canonical-storage-startup.ts`
+  `relocateTrashedPromptWorkspaceFromCanonicalRoot(dataRoot, activeRoot)`：
+  仅当 canonical 根存在 `data/.trash/cache/prompt-workspace`（旧 file-workspace 快照被误放入
+  权威根）时，非破坏 rename 到 `<activeRoot>/recovery/canonical-prompt-trash/prompt-workspace-<时间戳>-<pid>`，
+  从而让 `verifyInventory` 不再因未声明文件在每次 prompt 写操作（如删除 prompt 123）时抛
+  `canonical graph file inventory count mismatch`。
+  其它 `.trash` 形态（如 conflicts）不受影响；目标无非 SQLite 探测才跳过）。
+- 单测 3 例（relocate no-delete、其余 trash 不动、异常不存在时 no-op）。
+验证：`vitest` canonical-storage-startup + prompt-version-consistency → 2 files 18 passed；
+desktop `typecheck`、`eslint`、`pnpm build` 全部 exit 0（重建 `out/main/index.js`）。
+前版本 current-version fix 章节内注的 “out of scope delete-123 follow-up” 之删除阻塞已在本推进解决，
+但仍未 commit，待用户本机确认后可启动+正常删除 prompt-123 后统一提交同一 PR（#214）。
+
 ## Docs synced
 
 `spec/changes/active/prompt-current-version-missing-self-heal/`: proposal、specs/storage/spec、

--- a/spec/changes/active/prompt-current-version-missing-self-heal/implementation.md
+++ b/spec/changes/active/prompt-current-version-missing-self-heal/implementation.md
@@ -55,6 +55,16 @@ desktop `typecheck`、`eslint`、`pnpm build` 全部 exit 0（重建 `out/main/i
 前版本 current-version fix 章节内注的 “out of scope delete-123 follow-up” 之删除阻塞已在本推进解决，
 但仍未 commit，待用户本机确认后可启动+正常删除 prompt-123 后统一提交同一 PR（#214）。
 
+### Front-end deleteTag guard（新增，用户已本地确认）
+
+按产品决策（decision: 前端拦截并在 PR 评论留给维护者后续讨论底层可删除性），本分支追加：
+- `PromptDB.countTagReferences(tag)`（storage，精确数组匹配，忽略不可解析行）;
+- IPC `prompt:countTagReferences` + preload `window.api.prompt.countTagReferences`;
+- `TagManagerModal.handleDelete`：prompt 域删除前若引用计数>0 则提示并阻止，
+  不再进入 canonical 写导致 `prompt:deleteTag` 二次报 `current version is missing`。
+单测 `prompt-tag-references.test.ts`（2 passed）；desktop typecheck/build exit 0。
+
+
 ## Docs synced
 
 `spec/changes/active/prompt-current-version-missing-self-heal/`: proposal、specs/storage/spec、

--- a/spec/changes/active/prompt-current-version-missing-self-heal/implementation.md
+++ b/spec/changes/active/prompt-current-version-missing-self-heal/implementation.md
@@ -55,14 +55,19 @@ desktop `typecheck`、`eslint`、`pnpm build` 全部 exit 0（重建 `out/main/i
 前版本 current-version fix 章节内注的 “out of scope delete-123 follow-up” 之删除阻塞已在本推进解决，
 但仍未 commit，待用户本机确认后可启动+正常删除 prompt-123 后统一提交同一 PR（#214）。
 
-### Front-end deleteTag guard（新增，用户已本地确认）
+### Front-end deleteTag guard（新增，用户已本地确认；经 CodeRabbit 回合调整）
 
-按产品决策（decision: 前端拦截并在 PR 评论留给维护者后续讨论底层可删除性），本分支追加：
-- `PromptDB.countTagReferences(tag)`（storage，精确数组匹配，忽略不可解析行）;
-- IPC `prompt:countTagReferences` + preload `window.api.prompt.countTagReferences`;
-- `TagManagerModal.handleDelete`：prompt 域删除前若引用计数>0 则提示并阻止，
-  不再进入 canonical 写导致 `prompt:deleteTag` 二次报 `current version is missing`。
-单测 `prompt-tag-references.test.ts`（2 passed）；desktop typecheck/build exit 0。
+按产品决策（decision: 前端拦截并在 PR 评论留给维护者后续讨论底层可删除性）：
+- `PromptDB.deleteTagIfUnreferenced(tag)`（原子事务）：仅当没有任何 prompt 引用时才允许删除，返回
+  `{ deleted, referenced }`；参照数组精确匹配、忽略不可解析行，避免“先查再删”的两步竞态（CodeRabbit #4）。
+- `prompt:deleteTag` IPC：先校验 tag 为非空 string、失败以统一错误抛拒；捕获 DB 异常返回结构化
+  `{ deleted, referenced }` 或统一错误（CodeRabbit #2）；preload 对 `deleteTag` 声明显式返回类型
+  `Promise<{ deleted: boolean; referenced: number }>`（CodeRabbit #3）。
+- `TagManagerModal.handleDelete`：prompt 域单次调用 `deleteTag`，若返回 `referenced>0` 则提示并阻止，
+  否则（deleted）更新目录/同步；删除不再触发 canonical 写或 `current_version` 二次报错。
+- canonical relocate 清理改为 **best-effort**：任何失败（EACCES/EXDEV）仅记录完整错误、不再阻断启动
+  （CodeRabbit #1），且快照原样保留。
+单测 `prompt-tag-references` 4 passed + relocate 失败路径 case；desktop typecheck/build、eslint exit 0。
 
 
 ## Docs synced

--- a/spec/changes/active/prompt-current-version-missing-self-heal/proposal.md
+++ b/spec/changes/active/prompt-current-version-missing-self-heal/proposal.md
@@ -1,0 +1,47 @@
+# Proposal: Prompt `current_version` startup self-heal
+
+## Phase And Status
+
+- Phase: implement
+- Status: active
+- Primary requirement: `FR-PCVMISS-001`
+- Problem: 首次发布 canonical storage authority 时，`validateVersionSet` 发现某个
+  prompt 的 `current_version` 在 `prompt_versions` 中无对应行即抛错，
+  “Failed to initialize app: Prompt resource current version is missing”，
+  数据库因此无法启动（`C:\Users\90438\AppData\Roaming\PromptHub\data\prompthub.db`）。
+- Delivery flow: 修复分支实现 + 单元测试 + 用户本机确认后再提交/提 PR。
+
+## Why
+
+Prompt 版本链不变量为 `max(prompt_versions.version) == prompts.current_version > 0`，
+且该版本行必须存在。版本行被删/指针陈旧/从未写入等异常会造成 canonical storage
+校验阶段硬失败并阻止整个应用启动。既有 db 迁移
+（`fix_prompt_current_version_v1` / `repair_empty_prompt_version_chain_v1`）只在
+迁移首次运行时执行一次，已标记的数据库后续即便数据再次不一致也不会重跑，
+于是启动路径没有兜底。
+
+## Scope
+
+- In scope:
+  - 新增幂等的 db 层修复器，逐 prompt 收敛 `current_version`：
+    - 有版本行 → 收敛到 `MAX(version)`；
+    - 无版本行 → 由 prompt 当前内容补一条 v1 快照并把 `current_version` 置 1；
+  - canonical authority 首次发布前（`prepareSourceDatabase` 后）对源库执行该修复；
+  - 仅针对真实 SQLite 镜像（非 SQLite 内容跳过），不影响 recovery/其它流程；
+  - 单元测试覆盖收敛、补 v1、健康数据不触碰、幂等。
+- Out of scope:
+  - 修改 core `validateVersionSet` / canonical 图装配（保持纯校验 / 物化语义不变）；
+  - 修改 Skill / MCP / Plugin 版本语义；
+  - 不改变用户数据内容，只修正版本指针（无版本链时补一条基于当前内容的快照）。
+
+## Exit conditions
+
+- `FR-PCVMISS-001`：存在 prompt current_version 缺失的源库经一次 startup 后能通过
+  canonical 校验并正常发布。
+- `FR-PCVMISS-002`：修复幂等且只修改版本指针/补齐缺失 v1，不触碰其它 prompt 字段。
+- 修复器与启动接线单测 + `pnpm typecheck` 通过；用户本机用真实坏库确认后按流程提 PR。
+
+## Rollback
+
+- 纯启动期、幂等的 DB 收敛，无 schema 变更；`prompts.current_version` 会被改写为
+  既有版本历史，补入的 v1 基于字段原样。回退到 main 即撤销接线；重新同步版本链即可。

--- a/spec/changes/active/prompt-current-version-missing-self-heal/specs/storage/spec.md
+++ b/spec/changes/active/prompt-current-version-missing-self-heal/specs/storage/spec.md
@@ -1,0 +1,38 @@
+# Spec — Prompt `current_version` startup self-heal
+
+## Requirements
+
+### `FR-PCVMISS-001`
+A source PromptHub SQLite database whose prompt `current_version` does not match
+its stored version chain MUST be accepted at canonical authority publication:
+PromptHub MAY converge each prompt pointer to its latest stored version, and for
+a prompt with content but no version row MAY add a single snapshot of version 1
+taken from the current prompt fields, before projecting validated canonical files.
+
+### `FR-PCVMISS-002`
+The repair MUST be idempotent, MUST NOT modify prompt content or unrelated
+metadata, and MUST NOT fabricate a version number larger than what already exists
+in `prompt_versions`.
+
+### `FR-PCVMISS-003`
+The startup wiring MUST run only for a recognized real SQLite image at the source
+database (a non-SQLite file must be left untouched) so recovery flows and mock
+startup fixtures keep their existing behavior.
+
+## Acceptance scenarios
+
+- 库内某 prompt `current_version` = 3、却只有 v1/v2 两行 → 修复后成为 v2；
+  cache 残行保持数量不变，无损失。
+- 某 prompt 有内容却无任何版本行 → 修复后写入一条基于该 prompt 当前各字段的
+  v1 版本行并设 `current_version` = 1。
+- 健康 prompt（版本链完整且指针 == max）→ 完全不改动。
+- 重复运行修复 → 第二次为 no-op（幂等）。
+- 非 SQLite 源文件 → 接线函数直接跳过，不尝试打开、不发生异常。
+
+## Traceability
+
+| Requirement | Design | Verification | Task |
+| ----------- | ------ | ------------ | ---- |
+| FR-PCVMISS-001 | DES-PCV-001 | TEST-PCV-001..003 | T-PCV-001..003 |
+| FR-PCVMISS-002 | DES-PCV-001 | TEST-PCV-004 | T-PCV-003 |
+| FR-PCVMISS-003 | DES-PCV-002 | TEST-PCV-005 | T-PCV-004 |

--- a/spec/changes/active/prompt-current-version-missing-self-heal/tasks.md
+++ b/spec/changes/active/prompt-current-version-missing-self-heal/tasks.md
@@ -1,0 +1,20 @@
+# Tasks — prompt-current-version-missing-self-heal
+
+- [x] T-PCV-001（FR-PCV-001）在 `main` 创建修复分支 `fix/prompt-current-version-missing-self-heal`。
+- [x] T-PCV-002 建 active change 契约（proposal/spec/storage/spec/design/tasks/implementation）。
+- [x] T-PCV-003（FR-PCV-001/002，DES-PCV-001）db 层幂等修复器
+      `packages/db/src/prompt-version-consistency.ts`：
+      `current_version` 收敛到 `MAX(version)`；无版本行时补 v1 快照并置 1。
+- [x] T-PCV-004（FR-PCV-003，DES-PCV-002）startup 接线 `healPromptVersionPointers`
+      （SQLite 头探测 + 修复）置于 `prepareSourceDatabase` 之后、`publish` 之前。
+- [x] T-PCV-005 单元测试（真实 SQLite）：收敛、补 v1、健康不动、幂等、四种异常（绿）。
+- [x] T-PCV-006 desktop `pnpm typecheck`（tsc --noEmit）exit 0；db 包 typecheck exit 0。
+- [x] T-PCV-007 eslint（startup + 新测试）exit 0；desktop `pnpm build` exit 0（重新产出 `out/main/index.js`）。
+- [ ] T-PCV-008 用户本机用真实坏库确认后可启动后，再提交/推送/开 PR。
+
+## Verification notes
+
+- `pnpm typecheck`（packages/db）exit 0；`pnpm typecheck`（apps/desktop）无 diagnostics。
+- `vitest run tests/unit/main/prompt-version-consistency.test.ts`：4 passed。
+- `vitest run tests/unit/main/canonical-storage-startup.test.ts tests/unit/main/prompt-version-consistency.test.ts`：15 passed。
+- `pnpm build`（desktop）exit 0；eslint（相关文件）exit 0。


### PR DESCRIPTION
## Motivation

A Prompt whose `prompts.current_version` has no matching row in `prompt_versions`
made the first canonical-authority publication fail hard inside
`validateVersionSet` (`Prompt resource current version is missing`), so the app
could not start at all on that vault.

## Change

- New idempotent storage repair `repairPromptVersionConsistency` (packages/db):
  converges each prompt pointer to its latest stored version; when a prompt has
  content but no version row at all, seeds a v1 snapshot taken verbatim from the
  current prompt fields and sets `current_version = 1`. Healthy prompts are
  untouched and a second run is a no-op.
- Startup wiring in `canonical-storage-startup` (`healPromptVersionPointers'):
  runs after source-database preparation and before projecting canonical files,
  only for a recognized SQLite image (16-byte header), so non-SQLite fixtures
  and recovery flows keep their behavior.
- No core validation/materialization semantics changed; no new schema file.

Active change: `spec/changes/active/prompt-current-version-missing-self-heal`

## Verification

- vitest `prompt-version-consistency.test.ts`: 4 passed (converge / seed v1 / healthy-untouched / idempotent)
- vitest startup + module combination: 15 passed
- `pnpm typecheck` (packages/db, apps/desktop): exit 0
- eslint (startup + new test): exit 0
- `pnpm build` (desktop): exit 0 (out/main regenerated)
- User on broken `prompthub.db`: app now starts and enters main UI (startup failure gone)

## Known follow-up (not addressed here)

After healing, deleting the drifted prompt id `123` still fails with
`canonical graph file inventory count mismatch: .trash/cache/prompt-workspace/123/123.md`
— a pre-existing orphan file under the canonical authority root, likely unrelated
to this version-pointer heal. It is tracked separately for a follow-up change and
should be handled without touching this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 启动时自动修复提示词版本指针与版本记录不一致的问题，并为缺少版本记录的提示词创建初始快照。
  * 删除标签时自动检查引用情况，返回引用数量；仍被提示词使用的标签将无法删除并显示提示。
  * 启动过程中更安全地处理待恢复的提示词工作区，避免异常路径影响应用启动。

* **Bug 修复**
  * 标签修改和删除后，版本记录与当前版本保持同步。
  * 改善异常恢复场景下的数据保留行为。
  * 补充多语言删除提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->